### PR TITLE
Update zib-BloodPressure-eov-test-1_1b-01.xml

### DIFF
--- a/src/eOverdracht-4-0/Test/_reference/resources/resources-generic/zib-BloodPressure-eov-test-1_1b-01.xml
+++ b/src/eOverdracht-4-0/Test/_reference/resources/resources-generic/zib-BloodPressure-eov-test-1_1b-01.xml
@@ -126,7 +126,7 @@
         <valueCodeableConcept>
             <coding>
                 <system value="http://snomed.info/sct" />
-                <code value="33586001" />
+                <code value="102538003" />
                 <display value="Liggende posititie" />
             </coding>
         </valueCodeableConcept>


### PR DESCRIPTION
Changed body position code to the correct one, according to it's display value and the testscript: https://informatiestandaarden.nictiz.nl/wiki/vpk:V4.0_testgegevens_overdracht_sturend_overlapBgZ#:~:text=Liggende%20positie%20(code%20%3D%20%27-,102538003,-%27%20in%20codeSystem%20%27SNOMED