### PR TITLE
MM4697 - Fix Organization reference and test scenario numbering

### DIFF
--- a/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/PHR-Client/imm-retrieve-2-1.xml
+++ b/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/PHR-Client/imm-retrieve-2-1.xml
@@ -17,7 +17,7 @@
          <use value="work"/>
       </telecom>
    </contact>
-   <description value="Scenario 2.1 - Retrieve Immunization resources of Pieterse"/>
+   <description value="Scenario 1.1 - Retrieve Immunization resources of Pieterse"/>
    <origin>
       <index value="1"/>
       <profile>
@@ -33,7 +33,7 @@
       </profile>
    </destination>
    <test>
-      <name value="Scenario 2.1 - Retrieve Immunization resources"/>
+      <name value="Scenario 1.1 - Retrieve Immunization resources"/>
       <description value="Query Immunization resource"/>
       <action>
          <operation>

--- a/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-01.xml
+++ b/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-01.xml
@@ -111,7 +111,7 @@
       </coding>
     </function>
     <actor>
-      <reference value="Organization/imm-HealthcareProvider-Organization-03-1"/>
+      <reference value="Organization/imm-HealthcareProvider-Organization-03-01"/>
       <type value="Organization"/>
       <display value="GGD Hart voor Brabant"/>
     </actor>

--- a/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-02.xml
+++ b/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-02.xml
@@ -112,7 +112,7 @@
       </coding>
     </function>
     <actor>
-      <reference value="Organization/imm-HealthcareProvider-Organization-03-1"/>
+      <reference value="Organization/imm-HealthcareProvider-Organization-03-01"/>
       <type value="Organization"/>
       <display value="GGD Hart voor Brabant"/>
     </actor>

--- a/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-03.xml
+++ b/dev/FHIR4-0-1-MedMij-Test/Immunization-1-0/_reference/resources/imm-Immunization-03-03.xml
@@ -111,7 +111,7 @@
       </coding>
     </function>
     <actor>
-      <reference value="Organization/imm-HealthcareProvider-Organization-03-2"/>
+      <reference value="Organization/imm-HealthcareProvider-Organization-03-02"/>
       <type value="Organization"/>
       <display value="Veiligheidsregio Limburg-Noord"/>
     </actor>

--- a/src/Immunization-1-0/Test/PHR-Client/imm-retrieve-2-1.xml
+++ b/src/Immunization-1-0/Test/PHR-Client/imm-retrieve-2-1.xml
@@ -4,11 +4,11 @@
     <id value="imm-retrieve-2-1"/>
     <version value="R4-4.0.1"/>
     <name value="Immunization - Client - Test Scenario 1.1 - Retrieve Immunization resources of Pieterse"/>
-    <description value="Scenario 2.1 - Retrieve Immunization resources of Pieterse"/>
+    <description value="Scenario 1.1 - Retrieve Immunization resources of Pieterse"/>
     <nts:authToken patientResourceId="imm-Patient-02"/>
 
     <test>
-        <name value="Scenario 2.1 - Retrieve Immunization resources"/>
+        <name value="Scenario 1.1 - Retrieve Immunization resources"/>
         <description value="Query Immunization resource"/>
         <nts:include value="medmij/test.phr.search" scope="common" resource="Immunization"/>
         <nts:include value="canary-assert.response.successfulSearch" scope="common"/>

--- a/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-01.xml
+++ b/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-01.xml
@@ -73,7 +73,7 @@
          </coding>
       </function>
       <actor>
-         <reference value="Organization/imm-HealthcareProvider-Organization-03-1"/>
+         <reference value="Organization/imm-HealthcareProvider-Organization-03-01"/>
          <type value="Organization"/>
           <display value="GGD Hart voor Brabant"/>
       </actor>

--- a/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-02.xml
+++ b/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-02.xml
@@ -74,7 +74,7 @@
          </coding>
       </function>
       <actor>
-         <reference value="Organization/imm-HealthcareProvider-Organization-03-1"/>
+         <reference value="Organization/imm-HealthcareProvider-Organization-03-01"/>
          <type value="Organization"/>
           <display value="GGD Hart voor Brabant"/>
       </actor>

--- a/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-03.xml
+++ b/src/Immunization-1-0/Test/_reference/resources/imm-Immunization-03-03.xml
@@ -73,7 +73,7 @@
          </coding>
       </function>
       <actor>
-         <reference value="Organization/imm-HealthcareProvider-Organization-03-2"/>
+         <reference value="Organization/imm-HealthcareProvider-Organization-03-02"/>
          <type value="Organization"/>
           <display value="Veiligheidsregio Limburg-Noord"/>
       </actor>


### PR DESCRIPTION
One of the fixtures contains a broken reference to a Organization resource and this needs to be fixed. Another issue that needs to be corrected is a inconsistency in the numbering of the test scenarios.

This PR fixes the reference en corrects the test scenario numbering.