### PR TITLE
Add Bearer token for internal test patient

### DIFF
--- a/Configuration/QualificationTokens.json
+++ b/Configuration/QualificationTokens.json
@@ -790,5 +790,10 @@
     "familyName": "XXX_Roelfsema",
     "bsn": "999900146",
     "qualificationScript": "CiO Test"
+  },
+  {
+    "accessToken": "Bearer 848561e6-1ef9-11ee-be56-0242ac120002",
+    "resourceId": "Nictiz-internal-patient",
+    "qualificationScript": "Test patient for internal purposes"
   }
 ]

--- a/Configuration/QualificationTokensStaging.json
+++ b/Configuration/QualificationTokensStaging.json
@@ -790,5 +790,10 @@
     "familyName": "XXX_Roelfsema",
     "bsn": "999900146",
     "qualificationScript": "CiO Test"
+  },
+  {
+    "accessToken": "Bearer 848561e6-1ef9-11ee-be56-0242ac120002",
+    "resourceId": "Nictiz-internal-patient",
+    "qualificationScript": "Test patient for internal purposes"
   }
 ]


### PR DESCRIPTION
Volgens mij worden de velden `familyName` en `bsn` niet door Touchstone zelf gebruikt, dus ik heb ze weggelaten.

Ik weet dat ze in enkele ada2fhir-processen worden gebruikt om zeker te weten dat de id's van de subjects overeenkomen met de `resourceId` van de token. Dat is hier (nog) niet van toepassing.