### PR TITLE
EOVDR-428: Corrected family name extension from NL4 to NL1

### DIFF
--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-DisorderOfPregnancy276372004-0d47b511-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-DisorderOfPregnancy276372004-0d47b511-2063-11ec-1751-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 7b4aa0cf-a6d9-11ed-1544-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of pregnancy (disorder) (173300003 - SNOMED CT)">Disorder of pregnancy (disorder)</span>, <span title="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding) (418799008 - SNOMED CT)">bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)</span>, Status: inactief</caption>
+        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 7b4aa0cf-a6d9-11ed-1544-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="zwangerschapsstoornis (aandoening) (173300003 - SNOMED CT)">zwangerschapsstoornis (aandoening)</span>, <span title="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding) (418799008 - SNOMED CT)">bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)</span>, Status: inactief</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -43,7 +43,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="173300003"/>
-      <display value="Disorder of pregnancy (disorder)"/>
+      <display value="zwangerschapsstoornis (aandoening)"/>
     </coding>
   </category>
   <category>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalRecord-0d479b8b-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalRecord-0d479b8b-2063-11ec-1751-020000000000.xml
@@ -13,7 +13,7 @@
           <tr>
             <th>Type</th>
             <td>
-              <span title="Pregnancy observable (observable entity) (364320009 - SNOMED CT)">Pregnancy observable (observable entity)</span>
+              <span title="observatie betreffende zwangerschap (waarneembare entiteit) (364320009 - SNOMED CT)">observatie betreffende zwangerschap (waarneembare entiteit)</span>
             </td>
           </tr>
           <tr>
@@ -41,7 +41,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="364320009"/>
-      <display value="Pregnancy observable (observable entity)"/>
+      <display value="observatie betreffende zwangerschap (waarneembare entiteit)"/>
     </coding>
   </type>
   <diagnosis>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure241491007-0d47b516-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure241491007-0d47b516-2063-11ec-1751-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7bf343fa-a6d9-11ed-1922-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7bf343fa-a6d9-11ed-1922-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure281568006-0d47b51d-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure281568006-0d47b51d-2063-11ec-1751-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7c1c6d24-a6d9-11ed-1509-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7c1c6d24-a6d9-11ed-1509-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure445283009-0d47b519-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure445283009-0d47b519-2063-11ec-1751-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7c38a6af-a6d9-11ed-1217-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 7c38a6af-a6d9-11ed-1217-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-0d47a576-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-0d47a576-2063-11ec-1751-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
             </td>
             <td>
-              <span title="Rhc-positief (733120009 - SNOMED CT)">Rhc-positief</span>
+              <span title="fenotype c-positief (bevinding) (733120009 - SNOMED CT)">fenotype c-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="733120009"/>
-      <display value="Rhc-positief"/>
+      <display value="fenotype c-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-0d47a3b4-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-0d47a3b4-2063-11ec-1751-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
             </td>
             <td>
-              <span title="RhD-positief (165747007 - SNOMED CT)">RhD-positief</span>
+              <span title="fenotype D-positief (bevinding) (165747007 - SNOMED CT)">fenotype D-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="165747007"/>
-      <display value="RhD-positief"/>
+      <display value="fenotype D-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2025-030000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2025-030000000000.xml
@@ -19,7 +19,7 @@
           </tr>
           <tr>
             <td>
-              <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+              <span title="datum van laatste menstruatie (waarneembare entiteit) (21840007 - SNOMED CT)">datum van laatste menstruatie (waarneembare entiteit)</span>
             </td>
             <td>${DATE, T, D, -209}</td>
           </tr>
@@ -42,7 +42,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="21840007"/>
-      <display value="Date of last menstrual period"/>
+      <display value="datum van laatste menstruatie (waarneembare entiteit)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy118185001-0d47afc5-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy118185001-0d47afc5-2063-11ec-1751-020000000000.xml
@@ -12,7 +12,7 @@
           <tr>
             <th>Code</th>
             <td>
-              <span title="Finding related to pregnancy (finding) (118185001 - SNOMED CT)">Finding related to pregnancy (finding)</span>
+              <span title="bevinding betreffende zwangerschap (bevinding) (118185001 - SNOMED CT)">bevinding betreffende zwangerschap (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -32,7 +32,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="118185001"/>
-      <display value="Finding related to pregnancy (finding)"/>
+      <display value="bevinding betreffende zwangerschap (bevinding)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-TobaccoUse365980008-0d47afe9-2063-11ec-1751-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart1/medmij-gbz-zib-TobaccoUse365980008-0d47afe9-2063-11ec-1751-020000000000.xml
@@ -23,7 +23,7 @@
               <span title="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding) (365980008 - SNOMED CT)">bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)</span>
             </td>
             <td>
-              <span title="heeft nooit gerookt (266919005 - SNOMED CT)">heeft nooit gerookt</span>
+              <span title="heeft nooit gerookt (bevinding) (266919005 - SNOMED CT)">heeft nooit gerookt (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -54,7 +54,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="266919005"/>
-      <display value="heeft nooit gerookt"/>
+      <display value="heeft nooit gerookt (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthObservation364336006-d735d96f-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthObservation364336006-d735d96f-2062-11ec-2089-020000000000.xml
@@ -27,7 +27,7 @@
               <span title="soort partus (waarneembare entiteit) (364336006 - SNOMED CT)">soort partus (waarneembare entiteit)</span>
             </td>
             <td>
-              <span title="begeleiding van normale bevalling (verrichting) (177184002 - SNOMED CT)">begeleiding van normale bevalling (verrichting)</span>
+              <span title="begeleiding van normale partus (verrichting) (177184002 - SNOMED CT)">begeleiding van normale partus (verrichting)</span>
             </td>
           </tr>
         </tbody>
@@ -65,7 +65,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="177184002"/>
-      <display value="begeleiding van normale bevalling (verrichting)"/>
+      <display value="begeleiding van normale partus (verrichting)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthProcedure42857002-6b971017-a6d9-11ed-1698-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthProcedure42857002-6b971017-a6d9-11ed-1698-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Helen H.I. XXX_Kooij. Id: 6b971017-a6d9-11ed-1698-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Helen H.I. XXX_Kooij. Id: 6b971017-a6d9-11ed-1698-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -37,7 +37,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryProcedure236973005-d735d441-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryProcedure236973005-d735d441-2062-11ec-2089-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 1 (urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 1 (urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -33,7 +33,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery249166003-d835d977-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery249166003-d835d977-2062-11ec-2089-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 6c48ddf5-a6d9-11ed-2133-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of labor / delivery (disorder) (362972006 - SNOMED CT)">Disorder of labor / delivery (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 6c48ddf5-a6d9-11ed-2133-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="aandoening durante partu (aandoening) (362972006 - SNOMED CT)">aandoening durante partu (aandoening)</span>, Status: actief</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -43,7 +43,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="362972006"/>
-      <display value="Disorder of labor / delivery (disorder)"/>
+      <display value="aandoening durante partu (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery288274003-d735d977-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery288274003-d735d977-2062-11ec-2089-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 6c49ddf5-a6d9-11ed-2133-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of labor / delivery (disorder) (362972006 - SNOMED CT)">Disorder of labor / delivery (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Hanna H XXX_Kooij. Id: 6c49ddf5-a6d9-11ed-2133-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="aandoening durante partu (aandoening) (362972006 - SNOMED CT)">aandoening durante partu (aandoening)</span>, Status: actief</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -43,7 +43,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="362972006"/>
-      <display value="Disorder of labor / delivery (disorder)"/>
+      <display value="aandoening durante partu (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-MaternalRecord-d735bfeb-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-MaternalRecord-d735bfeb-2062-11ec-2089-020000000000.xml
@@ -13,7 +13,7 @@
           <tr>
             <th>Type</th>
             <td>
-              <span title="Pregnancy observable (observable entity) (364320009 - SNOMED CT)">Pregnancy observable (observable entity)</span>
+              <span title="observatie betreffende zwangerschap (waarneembare entiteit) (364320009 - SNOMED CT)">observatie betreffende zwangerschap (waarneembare entiteit)</span>
             </td>
           </tr>
           <tr>
@@ -41,7 +41,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="364320009"/>
-      <display value="Pregnancy observable (observable entity)"/>
+      <display value="observatie betreffende zwangerschap (waarneembare entiteit)"/>
     </coding>
   </type>
   <diagnosis>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure236992007-d735d451-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure236992007-d735d451-2062-11ec-2089-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 6c98d13b-a6d9-11ed-1016-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 6c98d13b-a6d9-11ed-1016-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure51597003-da260877-4e9b-11ec-4587-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure51597003-da260877-4e9b-11ec-4587-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 6c7ff3dd-a6d9-11ed-1083-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Hanna H XXX_Kooij. Id: 6c7ff3dd-a6d9-11ed-1083-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation161714006-d735d43a-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation161714006-d735d43a-2062-11ec-2089-020000000000.xml
@@ -17,7 +17,7 @@
           <tr>
             <th>Methode</th>
             <td>
-              <span title="aterme datum berekend door middel van diagnostische ultrasonografie (31541000146106 - SNOMED CT)">aterme datum berekend door middel van diagnostische ultrasonografie</span>
+              <span title="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding) (31541000146106 - SNOMED CT)">aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)</span>
             </td>
           </tr>
           <tr>
@@ -65,7 +65,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="31541000146106"/>
-      <display value="aterme datum berekend door middel van diagnostische ultrasonografie"/>
+      <display value="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)"/>
     </coding>
   </method>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1da0e1e1-8fdf-11ec-2025-030000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1da0e1e1-8fdf-11ec-2025-030000000000.xml
@@ -19,7 +19,7 @@
           </tr>
           <tr>
             <td>
-              <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+              <span title="datum van laatste menstruatie (waarneembare entiteit) (21840007 - SNOMED CT)">datum van laatste menstruatie (waarneembare entiteit)</span>
             </td>
             <td>${DATE, T, D, -895}</td>
           </tr>
@@ -42,7 +42,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="21840007"/>
-      <display value="Date of last menstrual period"/>
+      <display value="datum van laatste menstruatie (waarneembare entiteit)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy118185001-d735d436-2062-11ec-2089-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy118185001-d735d436-2062-11ec-2089-020000000000.xml
@@ -12,7 +12,7 @@
           <tr>
             <th>Code</th>
             <td>
-              <span title="Finding related to pregnancy (finding) (118185001 - SNOMED CT)">Finding related to pregnancy (finding)</span>
+              <span title="bevinding betreffende zwangerschap (bevinding) (118185001 - SNOMED CT)">bevinding betreffende zwangerschap (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -28,7 +28,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="118185001"/>
-      <display value="Finding related to pregnancy (finding)"/>
+      <display value="bevinding betreffende zwangerschap (bevinding)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-66aa442e-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-66aa442e-2064-11ec-5265-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 86e242bf-a6d9-11ed-1937-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of pregnancy (disorder) (173300003 - SNOMED CT)">Disorder of pregnancy (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 86e242bf-a6d9-11ed-1937-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="zwangerschapsstoornis (aandoening) (173300003 - SNOMED CT)">zwangerschapsstoornis (aandoening)</span>, Status: actief</caption>
         <tfoot>
           <tr>
             <td colspan="2">mw.door verwijzen naar Sophia</td>
@@ -44,7 +44,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="173300003"/>
-      <display value="Disorder of pregnancy (disorder)"/>
+      <display value="zwangerschapsstoornis (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalRecord-66aa2fcb-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalRecord-66aa2fcb-2064-11ec-5265-020000000000.xml
@@ -13,7 +13,7 @@
           <tr>
             <th>Type</th>
             <td>
-              <span title="Pregnancy observable (observable entity) (364320009 - SNOMED CT)">Pregnancy observable (observable entity)</span>
+              <span title="observatie betreffende zwangerschap (waarneembare entiteit) (364320009 - SNOMED CT)">observatie betreffende zwangerschap (waarneembare entiteit)</span>
             </td>
           </tr>
           <tr>
@@ -41,7 +41,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="364320009"/>
-      <display value="Pregnancy observable (observable entity)"/>
+      <display value="observatie betreffende zwangerschap (waarneembare entiteit)"/>
     </coding>
   </type>
   <diagnosis>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure396550006-66aa4432-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure396550006-66aa4432-2064-11ec-5265-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 8769b9e4-a6d9-11ed-1807-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 8769b9e4-a6d9-11ed-1807-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure410175003-66aa4435-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure410175003-66aa4435-2064-11ec-5265-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 8785f31d-a6d9-11ed-1293-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 8785f31d-a6d9-11ed-1293-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation161714006-66aa440f-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation161714006-66aa440f-2064-11ec-5265-020000000000.xml
@@ -21,7 +21,7 @@
           <tr>
             <th>Methode</th>
             <td>
-              <span title="aterme datum berekend door middel van diagnostische ultrasonografie (31541000146106 - SNOMED CT)">aterme datum berekend door middel van diagnostische ultrasonografie</span>
+              <span title="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding) (31541000146106 - SNOMED CT)">aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)</span>
             </td>
           </tr>
           <tr>
@@ -70,7 +70,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="31541000146106"/>
-      <display value="aterme datum berekend door middel van diagnostische ultrasonografie"/>
+      <display value="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)"/>
     </coding>
   </method>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-66aa3970-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-66aa3970-2064-11ec-5265-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
             </td>
             <td>
-              <span title="Rhc-positief (733120009 - SNOMED CT)">Rhc-positief</span>
+              <span title="fenotype c-positief (bevinding) (733120009 - SNOMED CT)">fenotype c-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="733120009"/>
-      <display value="Rhc-positief"/>
+      <display value="fenotype c-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-66aa37ae-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-66aa37ae-2064-11ec-5265-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
             </td>
             <td>
-              <span title="RhD-positief (165747007 - SNOMED CT)">RhD-positief</span>
+              <span title="fenotype D-positief (bevinding) (165747007 - SNOMED CT)">fenotype D-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="165747007"/>
-      <display value="RhD-positief"/>
+      <display value="fenotype D-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2014-030000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2014-030000000000.xml
@@ -19,7 +19,7 @@
           </tr>
           <tr>
             <td>
-              <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+              <span title="datum van laatste menstruatie (waarneembare entiteit) (21840007 - SNOMED CT)">datum van laatste menstruatie (waarneembare entiteit)</span>
             </td>
             <td>${DATE, T, D, -278}</td>
           </tr>
@@ -42,7 +42,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="21840007"/>
-      <display value="Date of last menstrual period"/>
+      <display value="datum van laatste menstruatie (waarneembare entiteit)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy118185001-66aa440b-2064-11ec-5265-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy118185001-66aa440b-2064-11ec-5265-020000000000.xml
@@ -12,7 +12,7 @@
           <tr>
             <th>Code</th>
             <td>
-              <span title="Finding related to pregnancy (finding) (118185001 - SNOMED CT)">Finding related to pregnancy (finding)</span>
+              <span title="bevinding betreffende zwangerschap (bevinding) (118185001 - SNOMED CT)">bevinding betreffende zwangerschap (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -28,7 +28,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="118185001"/>
-      <display value="Finding related to pregnancy (finding)"/>
+      <display value="bevinding betreffende zwangerschap (bevinding)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b11-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b11-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jusef J XXX_Kwee. Id: 8fde1ee5-a6d9-11ed-4101-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
+        <caption>Verrichting. Subject: Jusef J XXX_Kwee. Id: 8fde1ee5-a6d9-11ed-4101-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
         </caption>
         <tbody>
           <tr>
@@ -38,7 +38,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b2b-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b2b-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamal J XXX_Kwee. Id: 8fbd9440-a6d9-11ed-7507-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
+        <caption>Verrichting. Subject: Jamal J XXX_Kwee. Id: 8fbd9440-a6d9-11ed-7507-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
         </caption>
         <tbody>
           <tr>
@@ -38,7 +38,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryProcedure236973005-a4907b0f-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryProcedure236973005-a4907b0f-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 1 (urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 1 (urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid<span style="display: block;">Uitvoerende: Erasmus MC, Sophia kinderziekenhuis</span>
         </caption>
         <tbody>
           <tr>
@@ -34,7 +34,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfLaborAndDelivery15028002-a4907b1f-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfLaborAndDelivery15028002-a4907b1f-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 909e088a-a6d9-11ed-9691-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of labor / delivery (disorder) (362972006 - SNOMED CT)">Disorder of labor / delivery (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 909e088a-a6d9-11ed-9691-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="aandoening durante partu (aandoening) (362972006 - SNOMED CT)">aandoening durante partu (aandoening)</span>, Status: actief</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="362972006"/>
-      <display value="Disorder of labor / delivery (disorder)"/>
+      <display value="aandoening durante partu (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-a4907b00-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-a4907b00-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 90bc56da-a6d9-11ed-2859-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of pregnancy (disorder) (173300003 - SNOMED CT)">Disorder of pregnancy (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 90bc56da-a6d9-11ed-2859-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="zwangerschapsstoornis (aandoening) (173300003 - SNOMED CT)">zwangerschapsstoornis (aandoening)</span>, Status: actief</caption>
         <tbody>
           <tr>
             <th>Code</th>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="173300003"/>
-      <display value="Disorder of pregnancy (disorder)"/>
+      <display value="zwangerschapsstoornis (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy22033007-a4907b03-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy22033007-a4907b03-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 90dd5475-a6d9-11ed-1690-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Disorder of pregnancy (disorder) (173300003 - SNOMED CT)">Disorder of pregnancy (disorder)</span>, Status: actief</caption>
+        <caption>Aandoening. Subject: Jamila J XXX_Kwee. Id: 90dd5475-a6d9-11ed-1690-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="zwangerschapsstoornis (aandoening) (173300003 - SNOMED CT)">zwangerschapsstoornis (aandoening)</span>, Status: actief</caption>
         <tfoot>
           <tr>
             <td colspan="2">tweede kind blijft erg achter in ontwikkeling</td>
@@ -44,7 +44,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="173300003"/>
-      <display value="Disorder of pregnancy (disorder)"/>
+      <display value="zwangerschapsstoornis (aandoening)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalRecord-a490614b-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalRecord-a490614b-2291-11ec-8669-020000000000.xml
@@ -13,7 +13,7 @@
           <tr>
             <th>Type</th>
             <td>
-              <span title="Pregnancy observable (observable entity) (364320009 - SNOMED CT)">Pregnancy observable (observable entity)</span>
+              <span title="observatie betreffende zwangerschap (waarneembare entiteit) (364320009 - SNOMED CT)">observatie betreffende zwangerschap (waarneembare entiteit)</span>
             </td>
           </tr>
           <tr>
@@ -41,7 +41,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="364320009"/>
-      <display value="Pregnancy observable (observable entity)"/>
+      <display value="observatie betreffende zwangerschap (waarneembare entiteit)"/>
     </coding>
   </type>
   <diagnosis>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure243140006-a4907b3f-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure243140006-a4907b3f-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91dc1008-a6d9-11ed-3745-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91dc1008-a6d9-11ed-3745-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure32485007-a4907b0c-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure32485007-a4907b0c-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91ba9f17-a6d9-11ed-1953-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91ba9f17-a6d9-11ed-1953-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure396550006-a4907b09-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure396550006-a4907b09-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91fdbf82-a6d9-11ed-1432-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 91fdbf82-a6d9-11ed-1432-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b28-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b28-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 926d693d-a6d9-11ed-4631-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 926d693d-a6d9-11ed-4631-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b42-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b42-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 928e8f66-a6d9-11ed-1541-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 928e8f66-a6d9-11ed-1541-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -35,7 +35,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b22-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b22-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 92219510-a6d9-11ed-1976-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 92219510-a6d9-11ed-1976-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b39-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b39-2291-11ec-8669-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 924a0a23-a6d9-11ed-1662-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="Obstetric procedure (procedure) (386637004 - SNOMED CT)">Obstetric procedure (procedure)</span>, Status: voltooid</caption>
+        <caption>Verrichting. Subject: Jamila J XXX_Kwee. Id: 924a0a23-a6d9-11ed-1662-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Categorie: <span title="obstetrische verrichting (verrichting) (386637004 - SNOMED CT)">obstetrische verrichting (verrichting)</span>, Status: voltooid</caption>
         <tbody>
           <tr>
             <td>
@@ -39,7 +39,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="386637004"/>
-      <display value="Obstetric procedure (procedure)"/>
+      <display value="obstetrische verrichting (verrichting)"/>
     </coding>
   </category>
   <code>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-a4906e60-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-a4906e60-2291-11ec-8669-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
             </td>
             <td>
-              <span title="Rhc-positief (733120009 - SNOMED CT)">Rhc-positief</span>
+              <span title="fenotype c-positief (bevinding) (733120009 - SNOMED CT)">fenotype c-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="733120009"/>
-      <display value="Rhc-positief"/>
+      <display value="fenotype c-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-a4906c9e-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-a4906c9e-2291-11ec-8669-020000000000.xml
@@ -26,7 +26,7 @@
               <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
             </td>
             <td>
-              <span title="RhD-positief (165747007 - SNOMED CT)">RhD-positief</span>
+              <span title="fenotype D-positief (bevinding) (165747007 - SNOMED CT)">fenotype D-positief (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="165747007"/>
-      <display value="RhD-positief"/>
+      <display value="fenotype D-positief (bevinding)"/>
     </coding>
   </valueCodeableConcept>
 </Observation>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2019-030000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2019-030000000000.xml
@@ -19,7 +19,7 @@
           </tr>
           <tr>
             <td>
-              <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+              <span title="datum van laatste menstruatie (waarneembare entiteit) (21840007 - SNOMED CT)">datum van laatste menstruatie (waarneembare entiteit)</span>
             </td>
             <td>${DATE, T, D, -278}</td>
           </tr>
@@ -42,7 +42,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="21840007"/>
-      <display value="Date of last menstrual period"/>
+      <display value="datum van laatste menstruatie (waarneembare entiteit)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy118185001-a49075a7-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy118185001-a49075a7-2291-11ec-8669-020000000000.xml
@@ -12,7 +12,7 @@
           <tr>
             <th>Code</th>
             <td>
-              <span title="Finding related to pregnancy (finding) (118185001 - SNOMED CT)">Finding related to pregnancy (finding)</span>
+              <span title="bevinding betreffende zwangerschap (bevinding) (118185001 - SNOMED CT)">bevinding betreffende zwangerschap (bevinding)</span>
             </td>
           </tr>
         </tbody>
@@ -28,7 +28,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="118185001"/>
-      <display value="Finding related to pregnancy (finding)"/>
+      <display value="bevinding betreffende zwangerschap (bevinding)"/>
     </coding>
   </code>
   <subject>

--- a/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-TobaccoUse365980008-a4907ae9-2291-11ec-8669-020000000000.xml
+++ b/dev/FHIR3-0-2-Geboortezorg/Zwangerschapskaart/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-TobaccoUse365980008-a4907ae9-2291-11ec-8669-020000000000.xml
@@ -32,7 +32,7 @@
               <span title="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding) (365980008 - SNOMED CT)">bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)</span>
             </td>
             <td>
-              <span title="rookte vroeger (8517006 - SNOMED CT)">rookte vroeger</span>
+              <span title="rookte vroeger (bevinding) (8517006 - SNOMED CT)">rookte vroeger (bevinding)</span>
             </td>
           </tr>
           <tr>
@@ -75,7 +75,7 @@
     <coding>
       <system value="http://snomed.info/sct"/>
       <code value="8517006"/>
-      <display value="rookte vroeger"/>
+      <display value="rookte vroeger (bevinding)"/>
     </coding>
   </valueCodeableConcept>
   <component>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-cert-1_1b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-cert-1_1b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Cert/_reference/resources/resources-generic/nl-core-patient-eov-cert-1_1b-01.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Cert/_reference/resources/resources-generic/nl-core-patient-eov-cert-1_1b-01.xml
@@ -6,7 +6,7 @@
   <text>
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
-      <div>Id 999900080 (BSN), <span title="Naamsamenstelling: Eigennaam gevolgd door partnernaam">Maria XXX_Molog</span>, Vrouw, 18 september 1963, Geen meerling</div>
+      <div>Id 999900080 (BSN), <span title="Naamsamenstelling: Eigennaam">Maria XXX_Molog</span>, Vrouw, 18 september 1963, Geen meerling</div>
       <div>
         <a href="tel:+31620202020">+31620202020</a> (,  mobile), <a href="mailto:mariamolog@provider.nl">mariamolog@provider.nl</a> (E-mail Privé)</div>
       <div>Knolweg 1000, 9999XA Stitswerd, NLD (officieel Bezoek)</div>
@@ -25,7 +25,7 @@
   <active value="true"/>
   <name>
     <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-      <valueCode value="NL4"/>
+      <valueCode value="NL1"/>
     </extension>
     <text value="Maria XXX_Molog"/>
     <family value="XXX_Molog">

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_10b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_10b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_11b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_11b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1b-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_1b-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation-json.xml
@@ -62,6 +62,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_2b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation-xml.xml
@@ -62,6 +62,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_2b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_2b-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_2b-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_3b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_3b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_3b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_3b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_4b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_4b-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_4b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_4b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_5-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_5-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_5-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_5-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_6-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_6-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_6-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_6-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_7-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_7-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_7-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_7-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_8-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_8-REQUESTED.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_8-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_8-IN-PROGRESS2.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff-json.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff-json.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_9b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff-xml.xml
+++ b/dev/FHIR3-0-2-eOverdracht4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff-xml.xml
@@ -54,6 +54,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
+   <fixture id="initial-task-fixture">
+      <autocreate value="false"/>
+      <autodelete value="false"/>
+      <resource>
+         <reference value="../_reference/resources/resources-specific/eOverdracht-Task-eov-test-1_9b-IN-PROGRESS.xml"/>
+      </resource>
+   </fixture>
    <profile id="eOverdracht-Task">
       <reference value="http://nictiz.nl/fhir/StructureDefinition/eOverdracht-Task"/>
    </profile>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-DisorderOfPregnancy276372004-0d47b511-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-DisorderOfPregnancy276372004-0d47b511-2063-11ec-1751-020000000000.xml
@@ -1,50 +1,49 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="0d47b511-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7b4aa0cf-a6d9-11ed-1544-020000000000"/>
-   </identifier>
-   <clinicalStatus value="inactive"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="173300003"/>
-         <display value="Disorder of pregnancy (disorder)"/>
-      </coding>
-   </category>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="418799008"/>
-         <display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="276372004"/>
-         <display value="zwakke foetale bewegingen (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -10}"/>
-   <abatementDateTime value="${DATE, T, D, -6}"/>
+	<id value="0d47b511-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7b4aa0cf-a6d9-11ed-1544-020000000000" />
+	</identifier>
+	<clinicalStatus value="inactive" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="173300003" />
+			<display value="zwangerschapsstoornis (aandoening)" />
+		</coding>
+	</category>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="418799008" />
+			<display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="276372004" />
+			<display value="zwakke foetale bewegingen (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -10}" />
+	<abatementDateTime value="${DATE, T, D, -6}" />
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Encounter-0d47afdc-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Encounter-0d47afdc-2063-11ec-1751-020000000000.xml
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="0d47afdc-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7b67c855-a6d9-11ed-1111-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/1234000103-000"/>
-               <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-         <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -139}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </condition>
-   </diagnosis>
+	<id value="0d47afdc-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7b67c855-a6d9-11ed-1111-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/1234000103-000" />
+					<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+			<display value="Gemma XXX_Groeneboom XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -139}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Encounter-0d47afea-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Encounter-0d47afea-2063-11ec-1751-020000000000.xml
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="0d47afea-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7b85b7e1-a6d9-11ed-1105-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/1234000103-000"/>
-               <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-         <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -6}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </condition>
-   </diagnosis>
+	<id value="0d47afea-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7b85b7e1-a6d9-11ed-1105-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/1234000103-000" />
+					<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+			<display value="Gemma XXX_Groeneboom XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -6}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalObservation792807003-0d47afdb-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalObservation792807003-0d47afdb-2063-11ec-1751-020000000000.xml
@@ -1,36 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afdb-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7bbbc88c-a6d9-11ed-1034-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="792807003"/>
-         <display value="Folic acid intake (observable entity)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -139}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="29761000146100"/>
-         <display value="preconceptionele intake van foliumzuur via voeding (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47afdb-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7bbbc88c-a6d9-11ed-1034-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="792807003" />
+			<display value="Folic acid intake (observable entity)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -139}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="29761000146100" />
+			<display value="preconceptionele intake van foliumzuur via voeding (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalRecord-0d479b8b-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-MaternalRecord-0d479b8b-2063-11ec-1751-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <EpisodeOfCare xmlns="http://hl7.org/fhir">
-   <id value="0d479b8b-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7bd4a46f-a6d9-11ed-1748-020000000000"/>
-   </identifier>
-   <status value="active"/>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364320009"/>
-         <display value="Pregnancy observable (observable entity)"/>
-      </coding>
-   </type>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </condition>
-   </diagnosis>
-   <patient>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </patient>
-   <managingOrganization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-108001234"/>
-      <display value="Verloskundigenpraktijk 't Groen"/>
-   </managingOrganization>
-   <period>
-      <start value="${DATE, T, D, -139}"/>
-   </period>
-   <careManager>
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-         <valueReference>
-            <reference value="PractitionerRole/1234000103-000"/>
-            <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-         </valueReference>
-      </extension>
-      <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-      <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-   </careManager>
+	<id value="0d479b8b-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7bd4a46f-a6d9-11ed-1748-020000000000" />
+	</identifier>
+	<status value="active" />
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364320009" />
+			<display value="observatie betreffende zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</type>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</condition>
+	</diagnosis>
+	<patient>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</patient>
+	<managingOrganization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-108001234" />
+		<display value="Verloskundigenpraktijk 't Groen" />
+	</managingOrganization>
+	<period>
+		<start value="${DATE, T, D, -139}" />
+	</period>
+	<careManager>
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+			<valueReference>
+				<reference value="PractitionerRole/1234000103-000" />
+				<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+			</valueReference>
+		</extension>
+		<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+		<display value="Gemma XXX_Groeneboom XXX_Gras" />
+	</careManager>
 </EpisodeOfCare>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure241491007-0d47b516-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure241491007-0d47b516-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="0d47b516-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7bf343fa-a6d9-11ed-1922-020000000000"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="241491007"/>
-         <display value="echografie van foetus (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -139}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </reasonReference>
+	<id value="0d47b516-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7bf343fa-a6d9-11ed-1922-020000000000" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="241491007" />
+			<display value="echografie van foetus (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -139}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure281568006-0d47b51d-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure281568006-0d47b51d-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="0d47b51d-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7c1c6d24-a6d9-11ed-1509-020000000000"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="281568006"/>
-         <display value="monitoren van foetale hart (regime/therapie)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -6}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </reasonReference>
+	<id value="0d47b51d-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7c1c6d24-a6d9-11ed-1509-020000000000" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="281568006" />
+			<display value="monitoren van foetale hart (regime/therapie)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -6}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure445283009-0d47b519-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-ObstetricProcedure445283009-0d47b519-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="0d47b519-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7c38a6af-a6d9-11ed-1217-020000000000"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="445283009"/>
-         <display value="aanbieden van voorlichtingsmateriaal (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -139}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </reasonReference>
+	<id value="0d47b519-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7c38a6af-a6d9-11ed-1217-020000000000" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="445283009" />
+			<display value="aanbieden van voorlichtingsmateriaal (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -139}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bb6-2291-11ec-8669-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bb6-2291-11ec-8669-030000000000.xml
@@ -1,63 +1,63 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bb6-2291-11ec-8669-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
-                <tbody>
-                    <tr>
-                        <th>Context</th>
-                        <td>Zwangerschap 3 Vrouw1</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
-                        </td>
-                        <td>56 d</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-            <display value="Zwangerschap 3 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bb6-2291-11ec-8669-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/HANNAHXXX-KOOIJ" />
-        <display value="Hanna H XXX_Kooij"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-        <display value="Zwangerschap 3 Vrouw1"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -153}"/>
-    <valueQuantity>
-        <value value="56" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bb6-2291-11ec-8669-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<text>
+		<status value="extensions" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Context</th>
+						<td>Zwangerschap 3 Vrouw1</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
+						</td>
+						<td>56 d</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bb6-2291-11ec-8669-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -153}" />
+	<valueQuantity>
+		<value value="56" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2291-11ec-8669-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2291-11ec-8669-030000000000.xml
@@ -1,69 +1,69 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bc6-2291-11ec-8669-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
-                <tbody>
-                    <tr>
-                        <th>Context</th>
-                        <td>Zwangerschap 3 Vrouw1</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
-                        </td>
-                        <td>56 d</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-            <display value="Zwangerschap 3 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
-        <valueReference>
-            <reference value="Condition/0d47b511-2063-11ec-1751-020000000000"/>
-            <display value="Zwangerschap 3 Vrouw1 zwakke foetale bewegingen (bevinding)"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bc6-2291-11ec-8669-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/HANNAHXXX-KOOIJ" />
-        <display value="Hanna H XXX_Kooij"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-        <display value="Zwangerschap 3 Vrouw1"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -20}"/>
-    <valueQuantity>
-        <value value="189" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bc6-2291-11ec-8669-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<text>
+		<status value="extensions" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Context</th>
+						<td>Zwangerschap 3 Vrouw1</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
+						</td>
+						<td>56 d</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
+		<valueReference>
+			<reference value="Condition/0d47b511-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1 zwakke foetale bewegingen (bevinding)" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bc6-2291-11ec-8669-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -20}" />
+	<valueQuantity>
+		<value value="189" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation143881000146107-0d47afd2-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation143881000146107-0d47afd2-2063-11ec-1751-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afd2-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7cb09bbb-a6d9-11ed-2091-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="143881000146107"/>
-         <display value="aantal levende nakomelingen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -125}"/>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="241491007"/>
-         <display value="echografie van foetus (verrichting)"/>
-      </coding>
-   </method>
+	<id value="0d47afd2-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7cb09bbb-a6d9-11ed-2091-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="143881000146107" />
+			<display value="aantal levende nakomelingen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -125}" />
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="241491007" />
+			<display value="echografie van foetus (verrichting)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation147781000146105-0d47afce-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation147781000146105-0d47afce-2063-11ec-1751-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afce-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7ccf3c28-a6d9-11ed-1791-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="147781000146105"/>
-         <display value="definitieve uitgerekende datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -125}"/>
-   <valueDateTime value="${DATE, T, D, +94}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="241491007"/>
-         <display value="echografie van foetus (verrichting)"/>
-      </coding>
-   </method>
+	<id value="0d47afce-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7ccf3c28-a6d9-11ed-1791-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="147781000146105" />
+			<display value="definitieve uitgerekende datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -125}" />
+	<valueDateTime value="${DATE, T, D, +94}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="241491007" />
+			<display value="echografie van foetus (verrichting)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation161714006-0d47afc9-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation161714006-0d47afc9-2063-11ec-1751-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afc9-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7c5737a5-a6d9-11ed-1539-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161714006"/>
-         <display value="geschatte datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <valueDateTime value="${DATE, T, D, +99}"/>
-   <method>
-      <coding>
-         <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
-         <code value="OTH"/>
-         <display value="Anders"/>
-      </coding>
-      <text value="zwangerschapstest clearlypink met zwangerschapsduur-indicator"/>
-   </method>
+	<id value="0d47afc9-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7c5737a5-a6d9-11ed-1539-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161714006" />
+			<display value="geschatte datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueDateTime value="${DATE, T, D, +99}" />
+	<method>
+		<coding>
+			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
+			<code value="OTH" />
+			<display value="Anders" />
+		</coding>
+		<text value="zwangerschapstest clearlypink met zwangerschapsduur-indicator" />
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation246435002-0e47afc6-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation246435002-0e47afc6-2063-11ec-1751-020000000000.xml
@@ -1,37 +1,36 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0e47afc6-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e982d6b-a6d9-11ed-1097-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="246435002"/>
-         <display value="aantal foetussen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="0e47afc6-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e982d6b-a6d9-11ed-1097-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="246435002" />
+			<display value="aantal foetussen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation364618000-0d47aff1-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation364618000-0d47aff1-2063-11ec-1751-020000000000.xml
@@ -1,50 +1,49 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47aff1-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7c727415-a6d9-11ed-2063-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364618000"/>
-         <display value="bewegingspatroon van foetus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afea-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-6D Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -10}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="276372004"/>
-         <display value="zwakke foetale bewegingen (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <comment value="voelt sinds enkele dagen minder frequent bewegingen"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="418799008"/>
-         <display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)"/>
-      </coding>
-   </method>
+	<id value="0d47aff1-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7c727415-a6d9-11ed-2063-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364618000" />
+			<display value="bewegingspatroon van foetus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afea-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-6D Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -10}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="276372004" />
+			<display value="zwakke foetale bewegingen (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<comment value="voelt sinds enkele dagen minder frequent bewegingen" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="418799008" />
+			<display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation713651007-0d47afd6-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-bc-PregnancyObservation713651007-0d47afd6-2063-11ec-1751-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afd6-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7c8e9b1f-a6d9-11ed-1347-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="713651007"/>
-         <display value="voorgeschiedenis met zwangerschap met abortus als resultaat (situatie)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <valueString>
-      <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor">
-         <valueCode value="NASK"/>
-      </extension>
-   </valueString>
-   <comment value="mw. zegt vroege miskraam te hebben gehad enkele maanden na eerste kind, destijds geen verloskundige gezien"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="418799008"/>
-         <display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)"/>
-      </coding>
-   </method>
+	<id value="0d47afd6-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7c8e9b1f-a6d9-11ed-1347-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="713651007" />
+			<display value="voorgeschiedenis met zwangerschap met abortus als resultaat (situatie)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueString>
+		<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor">
+			<valueCode value="NASK" />
+		</extension>
+	</valueString>
+	<comment value="mw. zegt vroege miskraam te hebben gehad enkele maanden na eerste kind, destijds geen verloskundige gezien" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="418799008" />
+			<display value="bevinding gerapporteerd door patiënt of andere bron van voorgeschiedenis (bevinding)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-organization-2-16-840-1-113883-2-4-6-108001234.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-organization-2-16-840-1-113883-2-4-6-108001234.xml
@@ -1,72 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Organization xmlns="http://hl7.org/fhir">
-   <id value="2-16-840-1-113883-2-4-6-108001234"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-organization"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>OrganisatieId: 08001234 (AGB-Z)</caption>
-            <tbody>
-               <tr>
-                  <th>Naam</th>
-                  <td>Verloskundigenpraktijk 't Groen</td>
-               </tr>
-               <tr>
-                  <th>Type</th>
-                  <td>
-                     <span title="Verloskundigenpraktijk (G3 - RoleCodeNL Zorgaanbiedertype)">Verloskundigenpraktijk</span>
-                  </td>
-               </tr>
-               <tr>
-                  <th>Adres</th>
-                  <td>Groeneweg 1000, 1234ZZ STITSWERD, 157 (Werk)</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="http://fhir.nl/fhir/NamingSystem/agb-z"/>
-      <value value="08001234"/>
-   </identifier>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7cf04054-a6d9-11ed-9327-020000000000"/>
-   </identifier>
-   <type>
-      <coding>
-         <system value="http://nictiz.nl/fhir/NamingSystem/organization-type"/>
-         <version value="2020-11-11T00:00:00"/>
-         <code value="G3"/>
-         <display value="Verloskundigenpraktijk"/>
-      </coding>
-   </type>
-   <name value="Verloskundigenpraktijk 't Groen"/>
-   <address>
-      <use value="work"/>
-      <line value="Groeneweg 1000">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Groeneweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1000"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="1234ZZ"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
+	<id value="2-16-840-1-113883-2-4-6-108001234" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-organization" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>OrganisatieId: 08001234 (AGB-Z)</caption>
+				<tbody>
+					<tr>
+						<th>Naam</th>
+						<td>Verloskundigenpraktijk 't Groen</td>
+					</tr>
+					<tr>
+						<th>Type</th>
+						<td>
+							<span title="Verloskundigenpraktijk (G3 - RoleCodeNL Zorgaanbiedertype)">Verloskundigenpraktijk</span>
+						</td>
+					</tr>
+					<tr>
+						<th>Adres</th>
+						<td>Groeneweg 1000, 1234ZZ STITSWERD, 157 (Werk)</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="http://fhir.nl/fhir/NamingSystem/agb-z" />
+		<value value="08001234" />
+	</identifier>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7cf04054-a6d9-11ed-9327-020000000000" />
+	</identifier>
+	<type>
+		<coding>
+			<system value="http://nictiz.nl/fhir/NamingSystem/organization-type" />
+			<version value="2020-11-11T00:00:00" />
+			<code value="G3" />
+			<display value="Verloskundigenpraktijk" />
+		</coding>
+	</type>
+	<name value="Verloskundigenpraktijk 't Groen" />
+	<address>
+		<use value="work" />
+		<line value="Groeneweg 1000">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Groeneweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1000" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="1234ZZ" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
 </Organization>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-patient-HANNAHXXX-KOOIJ.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-patient-HANNAHXXX-KOOIJ.xml
@@ -1,83 +1,82 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="HANNAHXXX-KOOIJ"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Hanna H XXX_Kooij, Vrouw, 18 oktober 1985</div>
-         <div>Knolweg 1002, 9999ZZ STITSWERD, 157 (Privé Bezoek)</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
-      <value>
-         <extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
-            <valueCode value="masked"/>
-         </extension>
-      </value>
-   </identifier>
-   <name>
-      <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-         <valueCode value="NL1"/>
-      </extension>
-      <text value="Hanna XXX_Kooij"/>
-      <family value="XXX_Kooij">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Kooij"/>
-         </extension>
-      </family>
-      <given value="Hanna">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="H">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="female">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="http://hl7.org/fhir/v3/AdministrativeGender"/>
-               <code value="F"/>
-               <display value="Vrouw"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </gender>
-   <birthDate value="1985-10-18"/>
-   <address>
-      <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-AD-use">
-         <valueCode value="PHYS"/>
-      </extension>
-      <use value="home"/>
-      <type value="physical"/>
-      <line value="Knolweg 1002">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1002"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999ZZ"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
+	<id value="HANNAHXXX-KOOIJ" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Hanna H XXX_Kooij, Vrouw, 18 oktober 1985</div>
+			<div>Knolweg 1002, 9999ZZ STITSWERD, 157 (Privé Bezoek)</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="http://fhir.nl/fhir/NamingSystem/bsn" />
+		<value>
+			<extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
+				<valueCode value="masked" />
+			</extension>
+		</value>
+	</identifier>
+	<name>
+		<extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
+			<valueCode value="NL1" />
+		</extension>
+		<text value="Hanna XXX_Kooij" />
+		<family value="XXX_Kooij">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Kooij" />
+			</extension>
+		</family>
+		<given value="Hanna">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="H">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="female">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="http://hl7.org/fhir/v3/AdministrativeGender" />
+					<code value="F" />
+					<display value="Vrouw" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</gender>
+	<birthDate value="1985-10-18" />
+	<address>
+		<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-AD-use">
+			<valueCode value="PHYS" />
+		</extension>
+		<use value="home" />
+		<type value="physical" />
+		<line value="Knolweg 1002">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1002" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999ZZ" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
 </Patient>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-practitionerrole-1234000103-000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-nl-core-practitionerrole-1234000103-000.xml
@@ -1,51 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <PractitionerRole xmlns="http://hl7.org/fhir">
-   <id value="1234000103-000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-practitionerrole"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Zorgverlenerrol</caption>
-            <tbody>
-               <tr>
-                  <th>Zorgverlener</th>
-                  <td>
-                     <div>
-                        <a href="Practitioner/2-16-528-1-1007-3-112340001">Gemma XXX_Groeneboom XXX_Gras</a>
-                     </div>
-                  </td>
-               </tr>
-               <tr>
-                  <th>Specialisme</th>
-                  <td>
-                     <span title="Verloskundige (03.000 - http://fhir.nl/fhir/NamingSystem/uzi-rolcode)">Verloskundige</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7d48bb79-a6d9-11ed-4511-020000000000"/>
-   </identifier>
-   <practitioner>
-      <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-      <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-   </practitioner>
-   <organization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-108001234"/>
-      <display value="Verloskundigenpraktijk 't Groen"/>
-   </organization>
-   <specialty>
-      <coding>
-         <system value="http://fhir.nl/fhir/NamingSystem/uzi-rolcode"/>
-         <version value="2020-04-01T00:00:00"/>
-         <code value="03.000"/>
-         <display value="Verloskundige"/>
-      </coding>
-   </specialty>
+	<id value="1234000103-000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-practitionerrole" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Zorgverlenerrol</caption>
+				<tbody>
+					<tr>
+						<th>Zorgverlener</th>
+						<td>
+							<div>
+								<a href="Practitioner/2-16-528-1-1007-3-112340001">Gemma XXX_Groeneboom XXX_Gras</a>
+							</div>
+						</td>
+					</tr>
+					<tr>
+						<th>Specialisme</th>
+						<td>
+							<span title="Verloskundige (03.000 - http://fhir.nl/fhir/NamingSystem/uzi-rolcode)">Verloskundige</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7d48bb79-a6d9-11ed-4511-020000000000" />
+	</identifier>
+	<practitioner>
+		<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+		<display value="Gemma XXX_Groeneboom XXX_Gras" />
+	</practitioner>
+	<organization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-108001234" />
+		<display value="Verloskundigenpraktijk 't Groen" />
+	</organization>
+	<specialty>
+		<coding>
+			<system value="http://fhir.nl/fhir/NamingSystem/uzi-rolcode" />
+			<version value="2020-04-01T00:00:00" />
+			<code value="03.000" />
+			<display value="Verloskundige" />
+		</coding>
+	</specialty>
 </PractitionerRole>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-AlcoholUse228273003-0d47afe5-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-AlcoholUse228273003-0d47afe5-2063-11ec-1751-020000000000.xml
@@ -1,36 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afe5-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7d62fc67-a6d9-11ed-8464-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228273003"/>
-         <display value="bevinding betreffende alcoholgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-139D Vrouw1"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="105542008"/>
-         <display value="drinkt momenteel geen alcohol (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <comment value="tbv conceptie al gestopt met alcohol consumptie"/>
+	<id value="0d47afe5-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7d62fc67-a6d9-11ed-8464-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228273003" />
+			<display value="bevinding betreffende alcoholgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-139D Vrouw1" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="105542008" />
+			<display value="drinkt momenteel geen alcohol (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<comment value="tbv conceptie al gestopt met alcohol consumptie" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BloodPressure85354-9-0d47b531-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BloodPressure85354-9-0d47b531-2063-11ec-1751-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47b531-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7d7ea53c-a6d9-11ed-1119-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-139D Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -139}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="133"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="89"/>
-      </valueQuantity>
-   </component>
+	<id value="0d47b531-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7d7ea53c-a6d9-11ed-1119-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-139D Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -139}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="133" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="89" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BloodPressure85354-9-0d47b537-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BloodPressure85354-9-0d47b537-2063-11ec-1751-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47b537-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7d9afee1-a6d9-11ed-9730-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afea-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-6D Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -6}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="155"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="97"/>
-      </valueQuantity>
-   </component>
+	<id value="0d47b537-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7d9afee1-a6d9-11ed-9730-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afea-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-6D Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -6}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="155" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="97" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BodyWeight29463-7-0d47b535-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BodyWeight29463-7-0d47b535-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47b535-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7dd8161a-a6d9-11ed-1198-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="29463-7"/>
-         <display value="Body weight"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-139D Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -139}"/>
-   <valueQuantity>
-      <value value="71"/>
-      <unit value="kg"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="kg"/>
-   </valueQuantity>
+	<id value="0d47b535-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7dd8161a-a6d9-11ed-1198-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="29463-7" />
+			<display value="Body weight" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-139D Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -139}" />
+	<valueQuantity>
+		<value value="71" />
+		<unit value="kg" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="kg" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BodyWeight29463-7-0d47b53b-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-BodyWeight29463-7-0d47b53b-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47b53b-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7db4b03e-a6d9-11ed-2050-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="29463-7"/>
-         <display value="Body weight"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afea-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-6D Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -6}"/>
-   <valueQuantity>
-      <value value="78"/>
-      <unit value="kg"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="kg"/>
-   </valueQuantity>
+	<id value="0d47b53b-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7db4b03e-a6d9-11ed-2050-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="29463-7" />
+			<display value="Body weight" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afea-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-6D Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -6}" />
+	<valueQuantity>
+		<value value="78" />
+		<unit value="kg" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="kg" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-DrugUse228366006-0d47afe7-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-DrugUse228366006-0d47afe7-2063-11ec-1751-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afe7-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7df450f4-a6d9-11ed-9306-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228366006"/>
-         <display value="bevinding betreffende drugsgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-139D Vrouw1"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228368007"/>
-         <display value="heeft nooit drugs gebruikt"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47afe7-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7df450f4-a6d9-11ed-9306-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228366006" />
+			<display value="bevinding betreffende drugsgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-139D Vrouw1" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228368007" />
+			<display value="heeft nooit drugs gebruikt" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-0d47a576-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-0d47a576-2063-11ec-1751-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47a576-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-05-12</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
-                  </td>
-                  <td>
-                     <span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e39be79-a6d9-11ed-1753-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1159-3"/>
-         <display value="little c Ag [Presence] on Red Blood Cells"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="2021-05-12"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="733120009"/>
-         <display value="Rhc-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47a576-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-05-12</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
+						</td>
+						<td>
+							<span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e39be79-a6d9-11ed-1753-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1159-3" />
+			<display value="little c Ag [Presence] on Red Blood Cells" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="2021-05-12" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="733120009" />
+			<display value="fenotype c-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-0d47a3b4-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-0d47a3b4-2063-11ec-1751-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47a3b4-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-05-12</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e5841d5-a6d9-11ed-1966-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1305-2"/>
-         <display value="D Ag [Presence] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="2021-05-12"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="165747007"/>
-         <display value="RhD-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47a3b4-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-05-12</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
+						</td>
+						<td>
+							<span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e5841d5-a6d9-11ed-1966-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1305-2" />
+			<display value="D Ag [Presence] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="2021-05-12" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="165747007" />
+			<display value="fenotype D-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-0d47a1f2-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-0d47a1f2-2063-11ec-1751-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47a1f2-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-05-12</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="bloedgroep A (bevinding) (112144000 - SNOMED CT)">bloedgroep A (bevinding)</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e169cf9-a6d9-11ed-7240-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="883-9"/>
-         <display value="ABO group [Type] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="2021-05-12"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="112144000"/>
-         <display value="bloedgroep A (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47a1f2-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/HANNAHXXX-KOOIJ">Hanna H XXX_Kooij</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-05-12</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
+						</td>
+						<td>
+							<span title="bloedgroep A (bevinding) (112144000 - SNOMED CT)">bloedgroep A (bevinding)</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e169cf9-a6d9-11ed-7240-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="883-9" />
+			<display value="ABO group [Type] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<effectiveDateTime value="2021-05-12" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="112144000" />
+			<display value="bloedgroep A (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2025-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2025-030000000000.xml
@@ -1,53 +1,53 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="1ca0e1e1-8fdf-11ec-2025-030000000000" />
-    <meta>
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
-    </meta>
-    <text>
-        <status value="extensions" />
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 1ca0e1e1-8fdf-11ec-2025-030000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
-                <tbody>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
-                        </td>
-                        <td>${DATE, T, D, -139}</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-            <display value="Zwangerschap 3 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-        <value value="1ca0e1e1-8fdf-11ec-2025-030000000000" />
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="21840007" />
-            <display value="Date of last menstrual period" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/HANNAHXXX-KOOIJ" />
-        <display value="Hanna H XXX_Kooij"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-        <display value="Zwangerschap 3 Vrouw1"/>
-    </context>
-    <valueDateTime value="${DATE, T, D, -209}" />
+	<id value="1ca0e1e1-8fdf-11ec-2025-030000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
+	</meta>
+	<text>
+		<status value="extensions" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 1ca0e1e1-8fdf-11ec-2025-030000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+						</td>
+						<td>${DATE, T, D, -139}</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="1ca0e1e1-8fdf-11ec-2025-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="21840007" />
+			<display value="datum van laatste menstruatie (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueDateTime value="${DATE, T, D, -209}" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47afc7-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47afc7-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afc7-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e7b573b-a6d9-11ed-6610-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11996-6"/>
-         <display value="[#] Pregnancies"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161732006"/>
-         <display value="aantal zwangerschappen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="3"/>
-   </valueQuantity>
+	<id value="0d47afc7-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e7b573b-a6d9-11ed-6610-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11996-6" />
+			<display value="[#] Pregnancies" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161732006" />
+			<display value="aantal zwangerschappen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="3" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1751-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afc6-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/0d47afc5-2063-11ec-1751-020000000000"/>
-         <display value="Zwangerschap 3 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e992d6b-a6d9-11ed-1097-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11977-6"/>
-         <display value="[#] Parity"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364325004"/>
-         <display value="pariteit (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="0d47afc6-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/0d47afc5-2063-11ec-1751-020000000000" />
+			<display value="Zwangerschap 3 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e992d6b-a6d9-11ed-1097-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11977-6" />
+			<display value="[#] Parity" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364325004" />
+			<display value="pariteit (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy118185001-0d47afc5-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-Pregnancy118185001-0d47afc5-2063-11ec-1751-020000000000.xml
@@ -1,31 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="0d47afc5-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="f54f8a1c-a6d4-11ed-4775-020000000000"/>
-   </identifier>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7eb9fe2f-a6d9-11ed-1085-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118185001"/>
-         <display value="Finding related to pregnancy (finding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1"/>
-   </context>
+	<id value="0d47afc5-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="f54f8a1c-a6d4-11ed-4775-020000000000" />
+	</identifier>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7eb9fe2f-a6d9-11ed-1085-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118185001" />
+			<display value="bevinding betreffende zwangerschap (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/0d479b8b-2063-11ec-1751-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1" />
+	</context>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-TobaccoUse365980008-0d47afe9-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart1/medmij-gbz-zib-TobaccoUse365980008-0d47afe9-2063-11ec-1751-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0d47afe9-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7ed9fe38-a6d9-11ed-1859-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="365980008"/>
-         <display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000"/>
-      <display value="prenatale controle T-139D Vrouw1"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="266919005"/>
-         <display value="heeft nooit gerookt"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="0d47afe9-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7ed9fe38-a6d9-11ed-1859-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="365980008" />
+			<display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1751-020000000000" />
+		<display value="prenatale controle T-139D Vrouw1" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="266919005" />
+			<display value="heeft nooit gerookt (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-9271-8-d735d992-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-9271-8-d735d992-2062-11ec-2089-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d992-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6b45d845-a6d9-11ed-1089-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9271-8"/>
-         <display value="10 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueQuantity>
-      <value value="10"/>
-   </valueQuantity>
+	<id value="d735d992-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6b45d845-a6d9-11ed-1089-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9271-8" />
+			<display value="10 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueQuantity>
+		<value value="10" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-9274-2-d735d990-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-9274-2-d735d990-2062-11ec-2089-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d990-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6b65c706-a6d9-11ed-1615-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9274-2"/>
-         <display value="5 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueQuantity>
-      <value value="8"/>
-   </valueQuantity>
+	<id value="d735d990-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6b65c706-a6d9-11ed-1615-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9274-2" />
+			<display value="5 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueQuantity>
+		<value value="8" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthObservation364336006-d735d96f-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthObservation364336006-d735d96f-2062-11ec-2089-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d96f-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6b7f396c-a6d9-11ed-1452-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364336006"/>
-         <display value="soort partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}T12:04:00+02:00"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="177184002"/>
-         <display value="begeleiding van normale bevalling (verrichting)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="d735d96f-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6b7f396c-a6d9-11ed-1452-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364336006" />
+			<display value="soort partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}T12:04:00+02:00" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="177184002" />
+			<display value="begeleiding van normale partus (verrichting)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthProcedure42857002-6b971017-a6d9-11ed-1698-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-BirthProcedure42857002-6b971017-a6d9-11ed-1698-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="6b971017-a6d9-11ed-1698-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6b971017-a6d9-11ed-1698-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw1"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="3950001"/>
-         <display value="geboorte (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <reasonReference>
-      <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </reasonReference>
+	<id value="6b971017-a6d9-11ed-1698-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6b971017-a6d9-11ed-1698-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw1" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="3950001" />
+			<display value="geboorte (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<reasonReference>
+		<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ChildObservation8339-4-d735d986-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ChildObservation8339-4-d735d986-2062-11ec-2089-020000000000.xml
@@ -1,34 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d986-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6bae7b22-a6d9-11ed-1398-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8339-4"/>
-         <display value="Birth weight Measured"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="3415"/>
-      <unit value="gram"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g"/>
-   </valueQuantity>
+	<id value="d735d986-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6bae7b22-a6d9-11ed-1398-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8339-4" />
+			<display value="Birth weight Measured" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="3415" />
+		<unit value="gram" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation118861000146102-d735d972-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation118861000146102-d735d972-2062-11ec-2089-020000000000.xml
@@ -1,38 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d972-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c17485e-a6d9-11ed-3853-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118861000146102"/>
-         <display value="aantal geboren kinderen uit zwangerschap (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}T12:04:00+02:00"/>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="d735d972-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c17485e-a6d9-11ed-3853-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118861000146102" />
+			<display value="aantal geboren kinderen uit zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}T12:04:00+02:00" />
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation169812000-d735d974-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation169812000-d735d974-2062-11ec-2089-020000000000.xml
@@ -1,41 +1,40 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d974-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6bcd1b63-a6d9-11ed-6900-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169812000"/>
-         <display value="geboorteplaats (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169813005"/>
-         <display value="thuisbevalling (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="d735d974-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6bcd1b63-a6d9-11ed-6900-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169812000" />
+			<display value="geboorteplaats (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169813005" />
+			<display value="thuisbevalling (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation249120008-d735d44b-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation249120008-d735d44b-2062-11ec-2089-020000000000.xml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d44b-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6be6f418-a6d9-11ed-1178-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="249120008"/>
-         <display value="begin van eerste fase van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -586}T23:50:00+02:00"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169734005"/>
-         <display value="spontaan breken van vliezen (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="129265001"/>
-         <display value="evaluatie (kwalificatiewaarde)"/>
-      </coding>
-   </method>
+	<id value="d735d44b-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6be6f418-a6d9-11ed-1178-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="249120008" />
+			<display value="begin van eerste fase van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -586}T23:50:00+02:00" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169734005" />
+			<display value="spontaan breken van vliezen (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="129265001" />
+			<display value="evaluatie (kwalificatiewaarde)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation439771001-d735d446-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryObservation439771001-d735d446-2062-11ec-2089-020000000000.xml
@@ -1,44 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d446-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6bfd6e5a-a6d9-11ed-5906-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="439771001"/>
-         <display value="datum van gebeurtenis (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}T02:19:00+02:00"/>
-   <valueDateTime value="${DATE, T, D, -587}T02:19:00+02:00"/>
-   <comment value="5 cm ontsluiting"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="113011001"/>
-         <display value="palpatie (verrichting)"/>
-      </coding>
-   </method>
+	<id value="d735d446-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6bfd6e5a-a6d9-11ed-5906-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="439771001" />
+			<display value="datum van gebeurtenis (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}T02:19:00+02:00" />
+	<valueDateTime value="${DATE, T, D, -587}T02:19:00+02:00" />
+	<comment value="5 cm ontsluiting" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="113011001" />
+			<display value="palpatie (verrichting)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryProcedure236973005-d735d441-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DeliveryProcedure236973005-d735d441-2062-11ec-2089-020000000000.xml
@@ -1,39 +1,38 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="d735d441-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7"/>
-      <value value="1"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="236973005"/>
-         <display value="verlossing (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <reasonReference>
-      <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </reasonReference>
+	<id value="d735d441-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7" />
+		<value value="1" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="236973005" />
+			<display value="verlossing (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<reasonReference>
+		<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery249166003-d835d977-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery249166003-d835d977-2062-11ec-2089-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="d835d977-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c48ddf5-a6d9-11ed-2133-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="362972006"/>
-         <display value="Disorder of labor / delivery (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="249166003"/>
-         <display value="niet-vorderende uitdrijving (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -587}T12:02:00+02:00"/>
-   <abatementDateTime value="${DATE, T, D, -587}T12:04:00+02:00"/>
+	<id value="d835d977-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c48ddf5-a6d9-11ed-2133-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="362972006" />
+			<display value="aandoening durante partu (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="249166003" />
+			<display value="niet-vorderende uitdrijving (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -587}T12:02:00+02:00" />
+	<abatementDateTime value="${DATE, T, D, -587}T12:04:00+02:00" />
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery288274003-d735d977-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-DisorderOfLaborAndDelivery288274003-d735d977-2062-11ec-2089-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="d735d977-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c49ddf5-a6d9-11ed-2133-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="362972006"/>
-         <display value="Disorder of labor / delivery (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="288274003"/>
-         <display value="foetale nood durante partu (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -587}T12:02:00+02:00"/>
-   <abatementDateTime value="${DATE, T, D, -587}T12:04:00+02:00"/>
+	<id value="d735d977-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c49ddf5-a6d9-11ed-2133-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="362972006" />
+			<display value="aandoening durante partu (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="288274003" />
+			<display value="foetale nood durante partu (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -587}T12:02:00+02:00" />
+	<abatementDateTime value="${DATE, T, D, -587}T12:04:00+02:00" />
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-Encounter-0d47afdc-2063-11ec-1749-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-Encounter-0d47afdc-2063-11ec-1749-020000000000.xml
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="0d47afdc-2063-11ec-1749-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7b67c855-a7e9-11ed-1111-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/1234000103-000"/>
-               <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-         <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -587}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </condition>
-   </diagnosis>
+	<id value="0d47afdc-2063-11ec-1749-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7b67c855-a7e9-11ed-1111-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/1234000103-000" />
+					<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+			<display value="Gemma XXX_Groeneboom XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -587}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-MaternalRecord-d735bfeb-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-MaternalRecord-d735bfeb-2062-11ec-2089-020000000000.xml
@@ -1,48 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <EpisodeOfCare xmlns="http://hl7.org/fhir">
-   <id value="d735bfeb-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c63b701-a6d9-11ed-1940-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364320009"/>
-         <display value="Pregnancy observable (observable entity)"/>
-      </coding>
-   </type>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </condition>
-   </diagnosis>
-   <patient>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </patient>
-   <managingOrganization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-108001234"/>
-      <display value="Verloskundigenpraktijk 't Groen"/>
-   </managingOrganization>
-   <period>
-      <start value="${DATE, T, D, -841}"/>
-      <end value="${DATE, T, D, -587}"/>
-   </period>
-   <careManager>
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-         <valueReference>
-            <reference value="PractitionerRole/1234000103-000"/>
-            <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-         </valueReference>
-      </extension>
-      <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-      <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-   </careManager>
+	<id value="d735bfeb-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c63b701-a6d9-11ed-1940-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364320009" />
+			<display value="observatie betreffende zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</type>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</condition>
+	</diagnosis>
+	<patient>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</patient>
+	<managingOrganization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-108001234" />
+		<display value="Verloskundigenpraktijk 't Groen" />
+	</managingOrganization>
+	<period>
+		<start value="${DATE, T, D, -841}" />
+		<end value="${DATE, T, D, -587}" />
+	</period>
+	<careManager>
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+			<valueReference>
+				<reference value="PractitionerRole/1234000103-000" />
+				<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+			</valueReference>
+		</extension>
+		<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+		<display value="Gemma XXX_Groeneboom XXX_Gras" />
+	</careManager>
 </EpisodeOfCare>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure236992007-d735d451-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure236992007-d735d451-2062-11ec-2089-020000000000.xml
@@ -1,46 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="d735d451-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c98d13b-a6d9-11ed-1016-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw1"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="236992007"/>
-         <display value="episiotomie mediolateraal rechts (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -587}T12:04:00+02:00"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/d835d977-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 3 Vrouw1 niet vorderende uitdrijving"/>
-   </reasonReference>
+	<id value="d735d451-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c98d13b-a6d9-11ed-1016-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw1" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="236992007" />
+			<display value="episiotomie mediolateraal rechts (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -587}T12:04:00+02:00" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/d835d977-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 3 Vrouw1 niet vorderende uitdrijving" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure51597003-da260877-4e9b-11ec-4587-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-ObstetricProcedure51597003-da260877-4e9b-11ec-4587-020000000000.xml
@@ -1,46 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="da260877-4e9b-11ec-4587-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6c7ff3dd-a6d9-11ed-1083-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw1"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="51597003"/>
-         <display value="vaginaal toucher (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -587}T02:19:00+02:00"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </reasonReference>
+	<id value="da260877-4e9b-11ec-4587-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6c7ff3dd-a6d9-11ed-1083-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw1" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="51597003" />
+			<display value="vaginaal toucher (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -587}T02:19:00+02:00" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4809bb6-2291-11ec-8669-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4809bb6-2291-11ec-8669-030000000000.xml
@@ -1,75 +1,75 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4809bb6-2291-11ec-8669-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
-                <tbody>
-                    <tr>
-                        <th>Context</th>
-                        <td>Zwangerschap 1 Vrouw1</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
-                        </td>
-                        <td>294 d</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
-        <valueReference>
-            <reference value="Procedure/d735d441-2062-11ec-2089-020000000000"/>
-            <display value="Bevalling Zwangerschap 1 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
-        <valueReference>
-            <reference value="Condition/d835d977-2062-11ec-2089-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw1 niet vorderende uitdrijving"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4809bb6-2291-11ec-8669-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/HANNAHXXX-KOOIJ" />
-        <display value="Hanna H XXX_Kooij"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw1"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -601}"/>
-    <valueQuantity>
-        <value value="294" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4809bb6-2291-11ec-8669-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<text>
+		<status value="extensions" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 7bbbc88c-a6d9-11ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Context</th>
+						<td>Zwangerschap 1 Vrouw1</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Fetal gestational age (57036006 - SNOMED CT)">Fetal gestational age</span>
+						</td>
+						<td>294 d</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
+		<valueReference>
+			<reference value="Procedure/d735d441-2062-11ec-2089-020000000000" />
+			<display value="Bevalling Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
+		<valueReference>
+			<reference value="Condition/d835d977-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1 niet vorderende uitdrijving" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4809bb6-2291-11ec-8669-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -601}" />
+	<valueQuantity>
+		<value value="294" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation147781000146105-d735d43f-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation147781000146105-d735d43f-2062-11ec-2089-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d43f-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6cd14588-a6d9-11ed-1001-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="147781000146105"/>
-         <display value="definitieve uitgerekende datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueDateTime value="${DATE, T, D, -587}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="225308005"/>
-         <display value="observatie (regime/therapie)"/>
-      </coding>
-   </method>
+	<id value="d735d43f-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6cd14588-a6d9-11ed-1001-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="147781000146105" />
+			<display value="definitieve uitgerekende datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueDateTime value="${DATE, T, D, -587}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="225308005" />
+			<display value="observatie (regime/therapie)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation161714006-d735d43a-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation161714006-d735d43a-2062-11ec-2089-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d43a-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6cb83f8a-a6d9-11ed-1100-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161714006"/>
-         <display value="geschatte datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueDateTime value="${DATE, T, D, -587}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="31541000146106"/>
-         <display value="aterme datum berekend door middel van diagnostische ultrasonografie"/>
-      </coding>
-   </method>
+	<id value="d735d43a-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6cb83f8a-a6d9-11ed-1100-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161714006" />
+			<display value="geschatte datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueDateTime value="${DATE, T, D, -587}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="31541000146106" />
+			<display value="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation246435002-0e37afc6-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-bc-PregnancyObservation246435002-0e37afc6-2063-11ec-1751-020000000000.xml
@@ -1,37 +1,36 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="0e37afc6-2063-11ec-1751-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7e982d6b-a7d9-11ed-1097-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="246435002"/>
-         <display value="aantal foetussen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="0e37afc6-2063-11ec-1751-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="7e982d6b-a7d9-11ed-1097-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="246435002" />
+			<display value="aantal foetussen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-nl-core-patient-HELENXXX-KOOIJ.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-nl-core-patient-HELENXXX-KOOIJ.xml
@@ -1,64 +1,63 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="HELENXXX-KOOIJ"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Helen H.I. XXX_Kooij, Vrouw, ${DATE, T, D, -587}</div>
-         <div>Knolweg 1002, 9999ZZ STITSWERD ()</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d03fc99-a6d9-11ed-3907-020000000000"/>
-   </identifier>
-   <name>
-      <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-         <valueCode value="NL1"/>
-      </extension>
-      <family value="XXX_Kooij">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Kooij"/>
-         </extension>
-      </family>
-      <given value="Helen">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="H.I.">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="female"/>
-   <birthDate value="${DATE, T, D, -587}"/>
-   <address>
-      <line value="Knolweg 1002">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1002"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999ZZ"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
-   <multipleBirthBoolean value="false"/>
+	<id value="HELENXXX-KOOIJ" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Helen H.I. XXX_Kooij, Vrouw, ${DATE, T, D, -587}</div>
+			<div>Knolweg 1002, 9999ZZ STITSWERD ()</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d03fc99-a6d9-11ed-3907-020000000000" />
+	</identifier>
+	<name>
+		<extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
+			<valueCode value="NL1" />
+		</extension>
+		<family value="XXX_Kooij">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Kooij" />
+			</extension>
+		</family>
+		<given value="Helen">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="H.I.">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="female" />
+	<birthDate value="${DATE, T, D, -587}" />
+	<address>
+		<line value="Knolweg 1002">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1002" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999ZZ" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
+	<multipleBirthBoolean value="false" />
 </Patient>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-ApgarScore9272-6-d735d98e-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-ApgarScore9272-6-d735d98e-2062-11ec-2089-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d98e-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d1b7404-a6d9-11ed-1525-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9272-6"/>
-         <display value="1 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueQuantity>
-      <value value="7"/>
-   </valueQuantity>
+	<id value="d735d98e-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d1b7404-a6d9-11ed-1525-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9272-6" />
+			<display value="1 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueQuantity>
+		<value value="7" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BloodPressure85354-9-d735d995-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BloodPressure85354-9-d735d995-2062-11ec-2089-020000000000.xml
@@ -1,63 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d995-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d31ec5b-a6d9-11ed-1299-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1749-020000000000"/>
-      <display value="prenatale controle T-587D Vrouw1"/>
-   </context>
-   <effectivePeriod>
-      <start value="${DATE, T, D, -587}"/>
-      <end value="${DATE, T, D, -587}"/>
-   </effectivePeriod>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="95"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="50"/>
-      </valueQuantity>
-   </component>
+	<id value="d735d995-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d31ec5b-a6d9-11ed-1299-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1749-020000000000" />
+		<display value="prenatale controle T-587D Vrouw1" />
+	</context>
+	<effectivePeriod>
+		<start value="${DATE, T, D, -587}" />
+		<end value="${DATE, T, D, -587}" />
+	</effectivePeriod>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="95" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="50" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BodyHeight89269-5-d735d988-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BodyHeight89269-5-d735d988-2062-11ec-2089-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d988-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d4bc515-a6d9-11ed-1853-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8302-2"/>
-         <display value="Body height"/>
-      </coding>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="89269-5"/>
-         <display value="Body height Measured --at birth"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueQuantity>
-      <value value="49.7"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="d735d988-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d4bc515-a6d9-11ed-1853-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8302-2" />
+			<display value="Body height" />
+		</coding>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="89269-5" />
+			<display value="Body height Measured --at birth" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueQuantity>
+		<value value="49.7" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BodyWeight29463-7-d735d999-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-BodyWeight29463-7-d735d999-2062-11ec-2089-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d999-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d63b5c6-a6d9-11ed-1467-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="29463-7"/>
-         <display value="Body weight"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="Encounter/0d47afdc-2063-11ec-1749-020000000000"/>
-      <display value="prenatale controle T-587D Vrouw1"/>
-   </context>
-   <effectivePeriod>
-      <start value="${DATE, T, D, -587}"/>
-      <end value="${DATE, T, D, -587}"/>
-   </effectivePeriod>
-   <valueQuantity>
-      <value value="63"/>
-      <unit value="kg"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="kg"/>
-   </valueQuantity>
+	<id value="d735d999-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d63b5c6-a6d9-11ed-1467-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="29463-7" />
+			<display value="Body weight" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="Encounter/0d47afdc-2063-11ec-1749-020000000000" />
+		<display value="prenatale controle T-587D Vrouw1" />
+	</context>
+	<effectivePeriod>
+		<start value="${DATE, T, D, -587}" />
+		<end value="${DATE, T, D, -587}" />
+	</effectivePeriod>
+	<valueQuantity>
+		<value value="63" />
+		<unit value="kg" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="kg" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-HeadCircumference169876006-d735d98a-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-HeadCircumference169876006-d735d98a-2062-11ec-2089-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d98a-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d7c1a0a-a6d9-11ed-1189-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9843-4"/>
-         <display value="Head Occipital-frontal circumference"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169876006"/>
-         <display value=" hoofdomtrek bij geboorte (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HELENXXX-KOOIJ"/>
-      <display value="Helen H.I. XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -587}"/>
-   <valueQuantity>
-      <value value="33.6"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="d735d98a-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d7c1a0a-a6d9-11ed-1189-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9843-4" />
+			<display value="Head Occipital-frontal circumference" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169876006" />
+			<display value=" hoofdomtrek bij geboorte (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HELENXXX-KOOIJ" />
+		<display value="Helen H.I. XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -587}" />
+	<valueQuantity>
+		<value value="33.6" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1da0e1e1-8fdf-11ec-2025-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1da0e1e1-8fdf-11ec-2025-030000000000.xml
@@ -1,53 +1,53 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="1da0e1e1-8fdf-11ec-2025-030000000000" />
-    <meta>
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
-    </meta>
-    <text>
-        <status value="extensions" />
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 1ca0e1e1-8fdf-11ec-2025-030000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
-                <tbody>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
-                        </td>
-                        <td>${DATE, T, D, -895}</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw1"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-        <value value="1da0e1e1-8fdf-11ec-2025-030000000000" />
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="21840007" />
-            <display value="Date of last menstrual period" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/HANNAHXXX-KOOIJ" />
-        <display value="Hanna H XXX_Kooij"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw1"/>
-    </context>
-    <valueDateTime value="${DATE, T, D, -895}" />
+	<id value="1da0e1e1-8fdf-11ec-2025-030000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
+	</meta>
+	<text>
+		<status value="extensions" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: Hanna H XXX_Kooij. Id: 1ca0e1e1-8fdf-11ec-2025-030000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Date of last menstrual period (21840007 - SNOMED CT)">Date of last menstrual period</span>
+						</td>
+						<td>${DATE, T, D, -895}</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="1da0e1e1-8fdf-11ec-2025-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="21840007" />
+			<display value="datum van laatste menstruatie (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueDateTime value="${DATE, T, D, -895}" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-Gravidity161732006-d735d438-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-Gravidity161732006-d735d438-2062-11ec-2089-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d438-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6d95d2e9-a6d9-11ed-1949-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11996-6"/>
-         <display value="[#] Pregnancies"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161732006"/>
-         <display value="aantal zwangerschappen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="d735d438-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6d95d2e9-a6d9-11ed-1949-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11996-6" />
+			<display value="[#] Pregnancies" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161732006" />
+			<display value="aantal zwangerschappen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-Parity364325004-d735d437-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy-Parity364325004-d735d437-2062-11ec-2089-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="d735d437-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/d735d436-2062-11ec-2089-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw1"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6daeadcd-a6d9-11ed-7511-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11977-6"/>
-         <display value="[#] Parity"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364325004"/>
-         <display value="pariteit (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="d735d437-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/d735d436-2062-11ec-2089-020000000000" />
+			<display value="Zwangerschap 1 Vrouw1" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6daeadcd-a6d9-11ed-7511-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11977-6" />
+			<display value="[#] Parity" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364325004" />
+			<display value="pariteit (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy118185001-d735d436-2062-11ec-2089-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw1-Kaart2/medmij-gbz-zib-Pregnancy118185001-d735d436-2062-11ec-2089-020000000000.xml
@@ -1,27 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="d735d436-2062-11ec-2089-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="6dc8819d-a6d9-11ed-1580-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118185001"/>
-         <display value="Finding related to pregnancy (finding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/HANNAHXXX-KOOIJ"/>
-      <display value="Hanna H XXX_Kooij"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw1"/>
-   </context>
+	<id value="d735d436-2062-11ec-2089-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="6dc8819d-a6d9-11ed-1580-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118185001" />
+			<display value="bevinding betreffende zwangerschap (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/HANNAHXXX-KOOIJ" />
+		<display value="Hanna H XXX_Kooij" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/d735bfeb-2062-11ec-2089-020000000000" />
+		<display value="Zwangerschap 1 Vrouw1" />
+	</context>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-66aa442e-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-66aa442e-2064-11ec-5265-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="66aa442e-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="86e242bf-a6d9-11ed-1937-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="173300003"/>
-         <display value="Disorder of pregnancy (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="16356006"/>
-         <display value="meerlingzwangerschap (aandoening)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -205}"/>
-   <note>
-      <text value="mw.door verwijzen naar Sophia"/>
-   </note>
+	<id value="66aa442e-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="86e242bf-a6d9-11ed-1937-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="173300003" />
+			<display value="zwangerschapsstoornis (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="16356006" />
+			<display value="meerlingzwangerschap (aandoening)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -205}" />
+	<note>
+		<text value="mw.door verwijzen naar Sophia" />
+	</note>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-Encounter-66aa441d-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-Encounter-66aa441d-2064-11ec-5265-020000000000.xml
@@ -1,55 +1,54 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="66aa441d-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8706cce0-a6d9-11ed-5049-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/1234000103-000"/>
-               <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-         <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -205}"/>
-      <end value="${DATE, T, D, -205}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
+	<id value="66aa441d-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8706cce0-a6d9-11ed-5049-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/1234000103-000" />
+					<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+			<display value="Gemma XXX_Groeneboom XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -205}" />
+		<end value="${DATE, T, D, -205}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalObservation792807003-66aa441c-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalObservation792807003-66aa441c-2064-11ec-5265-020000000000.xml
@@ -1,36 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa441c-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8725600a-a6d9-11ed-1440-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="792807003"/>
-         <display value="Folic acid intake (observable entity)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="30391000146101"/>
-         <display value="geen preconceptionele intake van foliumzuur via voeding (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa441c-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8725600a-a6d9-11ed-1440-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="792807003" />
+			<display value="Folic acid intake (observable entity)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="30391000146101" />
+			<display value="geen preconceptionele intake van foliumzuur via voeding (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalRecord-66aa2fcb-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-MaternalRecord-66aa2fcb-2064-11ec-5265-020000000000.xml
@@ -1,48 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <EpisodeOfCare xmlns="http://hl7.org/fhir">
-   <id value="66aa2fcb-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="874b1a81-a6d9-11ed-1250-020000000000"/>
-   </identifier>
-   <status value="active"/>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364320009"/>
-         <display value="Pregnancy observable (observable entity)"/>
-      </coding>
-   </type>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
-   <patient>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </patient>
-   <managingOrganization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-108001234"/>
-      <display value="Verloskundigenpraktijk 't Groen"/>
-   </managingOrganization>
-   <period>
-      <start value="${DATE, T, D, -205}"/>
-      <end value="${DATE, T, D, -194}"/>
-   </period>
-   <careManager>
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-         <valueReference>
-            <reference value="PractitionerRole/1234000103-000"/>
-            <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-         </valueReference>
-      </extension>
-      <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-      <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-   </careManager>
+	<id value="66aa2fcb-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="874b1a81-a6d9-11ed-1250-020000000000" />
+	</identifier>
+	<status value="active" />
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364320009" />
+			<display value="observatie betreffende zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</type>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
+	<patient>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</patient>
+	<managingOrganization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-108001234" />
+		<display value="Verloskundigenpraktijk 't Groen" />
+	</managingOrganization>
+	<period>
+		<start value="${DATE, T, D, -205}" />
+		<end value="${DATE, T, D, -194}" />
+	</period>
+	<careManager>
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+			<valueReference>
+				<reference value="PractitionerRole/1234000103-000" />
+				<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+			</valueReference>
+		</extension>
+		<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+		<display value="Gemma XXX_Groeneboom XXX_Gras" />
+	</careManager>
 </EpisodeOfCare>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure396550006-66aa4432-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure396550006-66aa4432-2064-11ec-5265-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="66aa4432-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8769b9e4-a6d9-11ed-1807-020000000000"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="396550006"/>
-         <display value="bloedonderzoek (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -205}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="66aa4432-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8769b9e4-a6d9-11ed-1807-020000000000" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="396550006" />
+			<display value="bloedonderzoek (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -205}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure410175003-66aa4435-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-ObstetricProcedure410175003-66aa4435-2064-11ec-5265-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="66aa4435-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8785f31d-a6d9-11ed-1293-020000000000"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="410175003"/>
-         <display value="dieetmanagement (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -205}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="66aa4435-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8785f31d-a6d9-11ed-1293-020000000000" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="410175003" />
+			<display value="dieetmanagement (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -205}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2291-11ec-8667-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2291-11ec-8667-030000000000.xml
@@ -1,39 +1,39 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bc6-2291-11ec-8667-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bc6-2291-11ec-8667-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -219}"/>
-    <valueQuantity>
-        <value value="59" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bc6-2291-11ec-8667-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bc6-2291-11ec-8667-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -219}" />
+	<valueQuantity>
+		<value value="59" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation161714006-66aa440f-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation161714006-66aa440f-2064-11ec-5265-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa440f-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="87a491e4-a6d9-11ed-4375-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161714006"/>
-         <display value="geschatte datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, +10}"/>
-   <valueDateTime value="${DATE, T, D, -205}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="31541000146106"/>
-         <display value="aterme datum berekend door middel van diagnostische ultrasonografie"/>
-      </coding>
-   </method>
+	<id value="66aa440f-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="87a491e4-a6d9-11ed-4375-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161714006" />
+			<display value="geschatte datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, +10}" />
+	<valueDateTime value="${DATE, T, D, -205}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="31541000146106" />
+			<display value="aterme datum berekend door middel van diagnostische ultrasonografie (bevinding)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation246435002-66aa4414-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation246435002-66aa4414-2064-11ec-5265-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa4414-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="87c0c8ac-a6d9-11ed-6716-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="246435002"/>
-         <display value="aantal foetussen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <valueQuantity>
-      <value value="2"/>
-   </valueQuantity>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="241491007"/>
-         <display value="echografie van foetus (verrichting)"/>
-      </coding>
-   </method>
+	<id value="66aa4414-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="87c0c8ac-a6d9-11ed-6716-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="246435002" />
+			<display value="aantal foetussen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<valueQuantity>
+		<value value="2" />
+	</valueQuantity>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="241491007" />
+			<display value="echografie van foetus (verrichting)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation65147003-46aa440f-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-bc-PregnancyObservation65147003-46aa440f-2064-11ec-5265-020000000000.xml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="46aa440f-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="86a491e4-a6d9-11fd-4375-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="65147003"/>
-         <display value="tweelingzwangerschap (aandoening)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="3278292003"/>
-         <display value="echografische beeldvorming"/>
-      </coding>
-   </method>
-   <related>
-      <type value="derived-from"/>
-      <target>
-         <reference value="Observation/66aa4414-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2 aantal foetussen"/>
-      </target>
-   </related>
+	<id value="46aa440f-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="86a491e4-a6d9-11fd-4375-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="65147003" />
+			<display value="tweelingzwangerschap (aandoening)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="3278292003" />
+			<display value="echografische beeldvorming" />
+		</coding>
+	</method>
+	<related>
+		<type value="derived-from" />
+		<target>
+			<reference value="Observation/66aa4414-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2 aantal foetussen" />
+		</target>
+	</related>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-nl-core-patient-JAMILAJXXX-KWEE.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-nl-core-patient-JAMILAJXXX-KWEE.xml
@@ -1,79 +1,78 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="JAMILAJXXX-KWEE"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Jamila J XXX_Kwee, Vrouw, 20 oktober 1985</div>
-         <div>Knolweg 1000, 9999XA STITSWERD ()</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
-      <value>
-         <extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
-            <valueCode value="masked"/>
-         </extension>
-      </value>
-   </identifier>
-   <name>
-      <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-         <valueCode value="NL1"/>
-      </extension>
-      <text value="Jamilia XXX_Kwee"/>
-      <family value="XXX_Kwee">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Kwee"/>
-         </extension>
-      </family>
-      <given value="Jamila">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="J">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="female">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="http://hl7.org/fhir/v3/AdministrativeGender"/>
-               <code value="F"/>
-               <display value="Vrouw"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </gender>
-   <birthDate value="1985-10-20"/>
-   <address>
-      <line value="Knolweg 1000">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1000"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999XA"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
-   <multipleBirthBoolean value="false"/>
+	<id value="JAMILAJXXX-KWEE" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Jamila J XXX_Kwee, Vrouw, 20 oktober 1985</div>
+			<div>Knolweg 1000, 9999XA STITSWERD ()</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="http://fhir.nl/fhir/NamingSystem/bsn" />
+		<value>
+			<extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
+				<valueCode value="masked" />
+			</extension>
+		</value>
+	</identifier>
+	<name>
+		<extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
+			<valueCode value="NL1" />
+		</extension>
+		<text value="Jamilia XXX_Kwee" />
+		<family value="XXX_Kwee">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Kwee" />
+			</extension>
+		</family>
+		<given value="Jamila">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="J">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="female">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="http://hl7.org/fhir/v3/AdministrativeGender" />
+					<code value="F" />
+					<display value="Vrouw" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</gender>
+	<birthDate value="1985-10-20" />
+	<address>
+		<line value="Knolweg 1000">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1000" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999XA" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
+	<multipleBirthBoolean value="false" />
 </Patient>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-AlcoholUse228273003-66aa4425-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-AlcoholUse228273003-66aa4425-2064-11ec-5265-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa4425-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="880e65ab-a6d9-11ed-9619-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228273003"/>
-         <display value="bevinding betreffende alcoholgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa441d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-205D Vrouw2"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="105542008"/>
-         <display value="drinkt momenteel geen alcohol (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa4425-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="880e65ab-a6d9-11ed-9619-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228273003" />
+			<display value="bevinding betreffende alcoholgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa441d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-205D Vrouw2" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="105542008" />
+			<display value="drinkt momenteel geen alcohol (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-BloodPressure85354-9-66aa4960-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-BloodPressure85354-9-66aa4960-2064-11ec-5265-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa4960-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="88298621-a6d9-11ed-2697-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa441d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-205D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="114"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="87"/>
-      </valueQuantity>
-   </component>
+	<id value="66aa4960-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="88298621-a6d9-11ed-2697-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa441d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-205D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="114" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="87" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-BodyWeight29463-7-66aa4965-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-BodyWeight29463-7-66aa4965-2064-11ec-5265-020000000000.xml
@@ -1,58 +1,57 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa4965-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="884821d3-a6d9-11ed-1800-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="29463-7"/>
-         <display value="Body weight"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa441d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-205D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <valueQuantity>
-      <value value="63"/>
-      <unit value="kg"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="kg"/>
-   </valueQuantity>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8352-7"/>
-            <display value="Clothing worn during measure"/>
-         </coding>
-      </code>
-      <valueCodeableConcept>
-         <coding>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1"/>
-            <code value="MINIMAL"/>
-            <display value="Lichte kleding/ondergoed"/>
-         </coding>
-      </valueCodeableConcept>
-   </component>
+	<id value="66aa4965-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="884821d3-a6d9-11ed-1800-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="29463-7" />
+			<display value="Body weight" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa441d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-205D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<valueQuantity>
+		<value value="63" />
+		<unit value="kg" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="kg" />
+	</valueQuantity>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8352-7" />
+				<display value="Clothing worn during measure" />
+			</coding>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1" />
+				<code value="MINIMAL" />
+				<display value="Lichte kleding/ondergoed" />
+			</coding>
+		</valueCodeableConcept>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-DrugUse228366006-66aa4427-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-DrugUse228366006-66aa4427-2064-11ec-5265-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa4427-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8869cdd4-a6d9-11ed-1513-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228366006"/>
-         <display value="bevinding betreffende drugsgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa441d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-205D Vrouw2"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228368007"/>
-         <display value="heeft nooit drugs gebruikt"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa4427-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8869cdd4-a6d9-11ed-1513-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228366006" />
+			<display value="bevinding betreffende drugsgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa441d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-205D Vrouw2" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228368007" />
+			<display value="heeft nooit drugs gebruikt" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-66aa3970-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-66aa3970-2064-11ec-5265-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa3970-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-17</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
-                  </td>
-                  <td>
-                     <span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="88a09326-a6d9-11ed-3991-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1159-3"/>
-         <display value="little c Ag [Presence] on Red Blood Cells"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-17"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="733120009"/>
-         <display value="Rhc-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa3970-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-17</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
+						</td>
+						<td>
+							<span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="88a09326-a6d9-11ed-3991-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1159-3" />
+			<display value="little c Ag [Presence] on Red Blood Cells" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-17" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="733120009" />
+			<display value="fenotype c-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-66aa37ae-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-66aa37ae-2064-11ec-5265-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa37ae-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-17</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="88bf3240-a6d9-11ed-3911-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1305-2"/>
-         <display value="D Ag [Presence] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-17"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="165747007"/>
-         <display value="RhD-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa37ae-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-17</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
+						</td>
+						<td>
+							<span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="88bf3240-a6d9-11ed-3911-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1305-2" />
+			<display value="D Ag [Presence] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-17" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="165747007" />
+			<display value="fenotype D-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-66aa35ec-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-66aa35ec-2064-11ec-5265-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa35ec-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-17</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="bloedgroep O (bevinding) (58460004 - SNOMED CT)">bloedgroep O (bevinding)</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="88855931-a6d9-11ed-1630-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="883-9"/>
-         <display value="ABO group [Type] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-17"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="58460004"/>
-         <display value="bloedgroep O (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="66aa35ec-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-17</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
+						</td>
+						<td>
+							<span title="bloedgroep O (bevinding) (58460004 - SNOMED CT)">bloedgroep O (bevinding)</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="88855931-a6d9-11ed-1630-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="883-9" />
+			<display value="ABO group [Type] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-17" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="58460004" />
+			<display value="bloedgroep O (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-66aa3b32-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-66aa3b32-2064-11ec-5265-020000000000.xml
@@ -1,75 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa3b32-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-17</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
-                  </td>
-                  <td>7.3 g/dL</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="88dea095-a6d9-11ed-1191-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="93846-4"/>
-         <display value="Hemoglobin [Moles/volume] in Venous blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-17"/>
-   <valueQuantity>
-      <value value="7.3"/>
-      <unit value="g/dL"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g/dL"/>
-   </valueQuantity>
+	<id value="66aa3b32-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-17</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
+						</td>
+						<td>7.3 g/dL</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="88dea095-a6d9-11ed-1191-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="93846-4" />
+			<display value="Hemoglobin [Moles/volume] in Venous blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-17" />
+	<valueQuantity>
+		<value value="7.3" />
+		<unit value="g/dL" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g/dL" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2014-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2014-030000000000.xml
@@ -1,33 +1,33 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="1ca0e1e1-8fdf-11ec-2014-030000000000" />
-    <meta>
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-        <value value="1ca0e1e1-8fdf-11ec-2014-030000000000" />
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="21840007" />
-            <display value="Date of last menstrual period" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <valueDateTime value="${DATE, T, D, -278}" />
+	<id value="1ca0e1e1-8fdf-11ec-2014-030000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="1ca0e1e1-8fdf-11ec-2014-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="21840007" />
+			<display value="datum van laatste menstruatie (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueDateTime value="${DATE, T, D, -278}" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-Gravidity161732006-66aa440d-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-Gravidity161732006-66aa440d-2064-11ec-5265-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa440d-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8902b358-a6d9-11ed-7067-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11996-6"/>
-         <display value="[#] Pregnancies"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161732006"/>
-         <display value="aantal zwangerschappen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="66aa440d-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8902b358-a6d9-11ed-7067-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11996-6" />
+			<display value="[#] Pregnancies" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161732006" />
+			<display value="aantal zwangerschappen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-Parity364325004-66aa440c-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy-Parity364325004-66aa440c-2064-11ec-5265-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa440c-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="891e63c9-a6d9-11ed-1075-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11977-6"/>
-         <display value="[#] Parity"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364325004"/>
-         <display value="pariteit (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <valueQuantity>
-      <value value="0"/>
-   </valueQuantity>
+	<id value="66aa440c-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="891e63c9-a6d9-11ed-1075-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11977-6" />
+			<display value="[#] Parity" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364325004" />
+			<display value="pariteit (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueQuantity>
+		<value value="0" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy118185001-66aa440b-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-Pregnancy118185001-66aa440b-2064-11ec-5265-020000000000.xml
@@ -1,27 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="66aa440b-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="893cfe88-a6d9-11ed-1324-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118185001"/>
-         <display value="Finding related to pregnancy (finding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
+	<id value="66aa440b-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="893cfe88-a6d9-11ed-1324-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118185001" />
+			<display value="bevinding betreffende zwangerschap (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-TobaccoUse365980008-66aa442a-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-1elijn/medmij-gbz-zib-TobaccoUse365980008-66aa442a-2064-11ec-5265-020000000000.xml
@@ -1,69 +1,68 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="66aa442a-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="895b92b1-a6d9-11ed-3079-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="365980008"/>
-         <display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa441d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-205D Vrouw2"/>
-   </context>
-   <effectivePeriod>
-      <start value="2019-06-01"/>
-   </effectivePeriod>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="230059006"/>
-         <display value="rookt soms sigaretten (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <component>
-      <code>
-         <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="53661000146106" />
-            <display value="type tabak gebruikt (waarneembare entiteit)" />
-         </coding>
-      </code>
-      <valueCodeableConcept>
-         <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="722499006" />
-            <display value="gebruiker van elektronische sigaret" />
-         </coding>
-      </valueCodeableConcept>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="266918002" />
-            <display value="hoeveelheid en type tabak gerookt (waarneembare entiteit)" />
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="6" />
-         <unit value="inhalations per day" />
-         <system value="http://unitsofmeasure.org" />
-         <code value="{inhalations}/d" />
-      </valueQuantity>
-   </component>
+	<id value="66aa442a-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="895b92b1-a6d9-11ed-3079-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="365980008" />
+			<display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa441d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-205D Vrouw2" />
+	</context>
+	<effectivePeriod>
+		<start value="2019-06-01" />
+	</effectivePeriod>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="230059006" />
+			<display value="rookt soms sigaretten (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<component>
+		<code>
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="53661000146106" />
+				<display value="type tabak gebruikt (waarneembare entiteit)" />
+			</coding>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="722499006" />
+				<display value="gebruiker van elektronische sigaret" />
+			</coding>
+		</valueCodeableConcept>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="266918002" />
+				<display value="hoeveelheid en type tabak gerookt (waarneembare entiteit)" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="6" />
+			<unit value="inhalations per day" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="{inhalations}/d" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthObservation364336006-a4907b15-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthObservation364336006-a4907b15-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b15-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000"/>
-         <display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8f9b10e3-a6d9-11ed-2153-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364336006"/>
-         <display value="soort partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11466000"/>
-         <display value="sectio caesarea (verrichting)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4907b15-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000" />
+			<display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8f9b10e3-a6d9-11ed-2153-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364336006" />
+			<display value="soort partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11466000" />
+			<display value="sectio caesarea (verrichting)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthObservation364336006-a4907b15-2291-11ec-8669-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthObservation364336006-a4907b15-2291-11ec-8669-030000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b15-2291-11ec-8669-030000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/a4907b11-2291-11ec-8669-020000000000"/>
-         <display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8f9b10e3-a6d9-11ed-2153-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364336006"/>
-         <display value="soort partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11466000"/>
-         <display value="sectio caesarea (verrichting)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4907b15-2291-11ec-8669-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/a4907b11-2291-11ec-8669-020000000000" />
+			<display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8f9b10e3-a6d9-11ed-2153-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364336006" />
+			<display value="soort partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11466000" />
+			<display value="sectio caesarea (verrichting)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b11-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b11-2291-11ec-8669-020000000000.xml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b11-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8fde1ee5-a6d9-11ed-4101-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="3950001"/>
-         <display value="geboorte (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performer>
-      <actor>
-         <reference value="Organization/2-16-840-1-113883-2-4-6-106020806"/>
-         <display value="Erasmus MC, Sophia kinderziekenhuis"/>
-      </actor>
-   </performer>
-   <reasonReference>
-      <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="a4907b11-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8fde1ee5-a6d9-11ed-4101-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="3950001" />
+			<display value="geboorte (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performer>
+		<actor>
+			<reference value="Organization/2-16-840-1-113883-2-4-6-106020806" />
+			<display value="Erasmus MC, Sophia kinderziekenhuis" />
+		</actor>
+	</performer>
+	<reasonReference>
+		<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b2b-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-BirthProcedure42857002-a4907b2b-2291-11ec-8669-020000000000.xml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b2b-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8fbd9440-a6d9-11ed-7507-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="3950001"/>
-         <display value="geboorte (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performer>
-      <actor>
-         <reference value="Organization/2-16-840-1-113883-2-4-6-106020806"/>
-         <display value="Erasmus MC, Sophia kinderziekenhuis"/>
-      </actor>
-   </performer>
-   <reasonReference>
-      <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="a4907b2b-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8fbd9440-a6d9-11ed-7507-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="3950001" />
+			<display value="geboorte (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performer>
+		<actor>
+			<reference value="Organization/2-16-840-1-113883-2-4-6-106020806" />
+			<display value="Erasmus MC, Sophia kinderziekenhuis" />
+		</actor>
+	</performer>
+	<reasonReference>
+		<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ChildObservation8339-4-a4907b54-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ChildObservation8339-4-a4907b54-2291-11ec-8669-020000000000.xml
@@ -1,51 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b54-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="8ffcb051-a6d9-11ed-3797-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8339-4"/>
-         <display value="Birth weight Measured"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}T15:10:00+02:00"/>
-   <valueQuantity>
-      <value value="2605"/>
-      <unit value="gram"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g"/>
-   </valueQuantity>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8352-7"/>
-            <display value="Clothing worn during measure"/>
-         </coding>
-      </code>
-      <valueCodeableConcept>
-         <coding>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1"/>
-            <code value="DIAPER"/>
-            <display value="Luier"/>
-         </coding>
-      </valueCodeableConcept>
-   </component>
+	<id value="a4907b54-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="8ffcb051-a6d9-11ed-3797-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8339-4" />
+			<display value="Birth weight Measured" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}T15:10:00+02:00" />
+	<valueQuantity>
+		<value value="2605" />
+		<unit value="gram" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g" />
+	</valueQuantity>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8352-7" />
+				<display value="Clothing worn during measure" />
+			</coding>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1" />
+				<code value="DIAPER" />
+				<display value="Luier" />
+			</coding>
+		</valueCodeableConcept>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ChildObservation8339-4-a4907b72-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ChildObservation8339-4-a4907b72-2291-11ec-8669-020000000000.xml
@@ -1,51 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b72-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9020bd6c-a6d9-11ed-1913-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8339-4"/>
-         <display value="Birth weight Measured"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}T15:05:00+02:00"/>
-   <valueQuantity>
-      <value value="2089"/>
-      <unit value="gram"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g"/>
-   </valueQuantity>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8352-7"/>
-            <display value="Clothing worn during measure"/>
-         </coding>
-      </code>
-      <valueCodeableConcept>
-         <coding>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1"/>
-            <code value="UNDRESSED"/>
-            <display value="Zonder kleding."/>
-         </coding>
-      </valueCodeableConcept>
-   </component>
+	<id value="a4907b72-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ChildObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9020bd6c-a6d9-11ed-1913-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8339-4" />
+			<display value="Birth weight Measured" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}T15:05:00+02:00" />
+	<valueQuantity>
+		<value value="2089" />
+		<unit value="gram" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g" />
+	</valueQuantity>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8352-7" />
+				<display value="Clothing worn during measure" />
+			</coding>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.8.1" />
+				<code value="UNDRESSED" />
+				<display value="Zonder kleding." />
+			</coding>
+		</valueCodeableConcept>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation118861000146102-a4907b18-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation118861000146102-a4907b18-2291-11ec-8669-020000000000.xml
@@ -1,38 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b18-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000"/>
-         <display value="bevalling zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="905ebd26-a6d9-11ed-1580-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118861000146102"/>
-         <display value="aantal geboren kinderen uit zwangerschap (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00"/>
-   <valueQuantity>
-      <value value="2"/>
-   </valueQuantity>
+	<id value="a4907b18-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000" />
+			<display value="bevalling zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="905ebd26-a6d9-11ed-1580-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118861000146102" />
+			<display value="aantal geboren kinderen uit zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00" />
+	<valueQuantity>
+		<value value="2" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation169812000-a4907b1b-2291-11ec-8661-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation169812000-a4907b1b-2291-11ec-8661-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b1b-2291-11ec-8661-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/a4907b11-2291-11ec-8669-020000000000"/>
-         <display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="903fa925-a6d9-11ed-1921-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169812000"/>
-         <display value="geboorteplaats (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="56321000146103"/>
-         <display value="geboorte in ziekenhuis (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <comment value="geplande sectio"/>
+	<id value="a4907b1b-2291-11ec-8661-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/a4907b11-2291-11ec-8669-020000000000" />
+			<display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="903fa925-a6d9-11ed-1921-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169812000" />
+			<display value="geboorteplaats (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="56321000146103" />
+			<display value="geboorte in ziekenhuis (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<comment value="geplande sectio" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation169812000-a4907b1b-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryObservation169812000-a4907b1b-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b1b-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000"/>
-         <display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="903fa935-a6d9-11ed-1921-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169812000"/>
-         <display value="geboorteplaats (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="56321000146103"/>
-         <display value="geboorte in ziekenhuis (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4907b1b-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-BirthObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000" />
+			<display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="903fa935-a6d9-11ed-1921-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169812000" />
+			<display value="geboorteplaats (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}T14:38:00+02:00" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="56321000146103" />
+			<display value="geboorte in ziekenhuis (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryProcedure236973005-a4907b0f-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DeliveryProcedure236973005-a4907b0f-2291-11ec-8669-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b0f-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7"/>
-      <value value="1"/>
-   </identifier>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="236973005"/>
-         <display value="verlossing (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performer>
-      <actor>
-         <reference value="Organization/2-16-840-1-113883-2-4-6-106020806"/>
-         <display value="Erasmus MC, Sophia kinderziekenhuis"/>
-      </actor>
-   </performer>
-   <reasonReference>
-      <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="a4907b0f-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.60.7" />
+		<value value="1" />
+	</identifier>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="236973005" />
+			<display value="verlossing (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performer>
+		<actor>
+			<reference value="Organization/2-16-840-1-113883-2-4-6-106020806" />
+			<display value="Erasmus MC, Sophia kinderziekenhuis" />
+		</actor>
+	</performer>
+	<reasonReference>
+		<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfLaborAndDelivery15028002-a4907b1f-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfLaborAndDelivery15028002-a4907b1f-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="a4907b1f-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Procedure/a4907b11-2291-11ec-8669-020000000000"/>
-         <display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="909e088a-a6d9-11ed-9691-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="362972006"/>
-         <display value="Disorder of labor / delivery (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="15028002"/>
-         <display value="liggingsafwijking van foetus (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -5}"/>
+	<id value="a4907b1f-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfLaborAndDelivery" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Procedure/a4907b11-2291-11ec-8669-020000000000" />
+			<display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="909e088a-a6d9-11ed-9691-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="362972006" />
+			<display value="aandoening durante partu (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="15028002" />
+			<display value="liggingsafwijking van foetus (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -5}" />
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-a4907b00-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy16356006-a4907b00-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="a4907b00-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="90bc56da-a6d9-11ed-2859-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="173300003"/>
-         <display value="Disorder of pregnancy (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="16356006"/>
-         <display value="meerlingzwangerschap (aandoening)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -193}"/>
+	<id value="a4907b00-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="90bc56da-a6d9-11ed-2859-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="173300003" />
+			<display value="zwangerschapsstoornis (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="16356006" />
+			<display value="meerlingzwangerschap (aandoening)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -193}" />
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy22033007-a4907b03-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-DisorderOfPregnancy22033007-a4907b03-2291-11ec-8669-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="a4907b03-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy"/>
-   </meta>
-   <extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="90dd5475-a6d9-11ed-1690-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="173300003"/>
-         <display value="Disorder of pregnancy (disorder)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="22033007"/>
-         <display value="intra-uteriene groeiretardatie (aandoening)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <onsetDateTime value="${DATE, T, D, -76}"/>
-   <note>
-      <text value="tweede kind blijft erg achter in ontwikkeling"/>
-   </note>
+	<id value="a4907b03-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-DisorderOfPregnancy" />
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/condition-partOf">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="90dd5475-a6d9-11ed-1690-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="173300003" />
+			<display value="zwangerschapsstoornis (aandoening)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="22033007" />
+			<display value="intra-uteriene groeiretardatie (aandoening)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<onsetDateTime value="${DATE, T, D, -76}" />
+	<note>
+		<text value="tweede kind blijft erg achter in ontwikkeling" />
+	</note>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-66aa521d-2064-11ec-5265-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-66aa521d-2064-11ec-5265-020000000000.xml
@@ -1,55 +1,54 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="66aa521d-2064-11ec-5265-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="66aa521d-2064-11ec-5265-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/1234000103-000"/>
-               <display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-112340001"/>
-         <display value="Gemma XXX_Groeneboom XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -5}"/>
-      <end value="${DATE, T, D, -5}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
+	<id value="66aa521d-2064-11ec-5265-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="66aa521d-2064-11ec-5265-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/1234000103-000" />
+					<display value="Verloskundige Gemma XXX_Groeneboom XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-112340001" />
+			<display value="Gemma XXX_Groeneboom XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -5}" />
+		<end value="${DATE, T, D, -5}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-a4907ad7-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-a4907ad7-2291-11ec-8669-020000000000.xml
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="a4907ad7-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="90fe539f-a6d9-11ed-9465-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/9876543201-046"/>
-               <display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-198765432"/>
-         <display value="Eduard XXX_Egelinks XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -193}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
+	<id value="a4907ad7-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="90fe539f-a6d9-11ed-9465-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/9876543201-046" />
+					<display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-198765432" />
+			<display value="Eduard XXX_Egelinks XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -193}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-a4907afa-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Encounter-a4907afa-2291-11ec-8669-020000000000.xml
@@ -1,53 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Encounter xmlns="http://hl7.org/fhir">
-   <id value="a4907afa-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="911f5102-a6d9-11ed-1566-020000000000"/>
-   </identifier>
-   <status value="finished"/>
-   <class>
-      <system value="http://hl7.org/fhir/v3/ActCode"/>
-      <code value="AMB"/>
-      <display value="ambulatory"/>
-   </class>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="11429006"/>
-         <display value="consult (verrichting)"/>
-      </coding>
-   </type>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <episodeOfCare>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </episodeOfCare>
-   <participant>
-      <individual>
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-            <valueReference>
-               <reference value="PractitionerRole/9876543201-046"/>
-               <display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras"/>
-            </valueReference>
-         </extension>
-         <reference value="Practitioner/2-16-528-1-1007-3-198765432"/>
-         <display value="Eduard XXX_Egelinks XXX_Gras"/>
-      </individual>
-   </participant>
-   <period>
-      <start value="${DATE, T, D, -76}"/>
-   </period>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
+	<id value="a4907afa-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Encounter" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="911f5102-a6d9-11ed-1566-020000000000" />
+	</identifier>
+	<status value="finished" />
+	<class>
+		<system value="http://hl7.org/fhir/v3/ActCode" />
+		<code value="AMB" />
+		<display value="ambulatory" />
+	</class>
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="11429006" />
+			<display value="consult (verrichting)" />
+		</coding>
+	</type>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<episodeOfCare>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</episodeOfCare>
+	<participant>
+		<individual>
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+				<valueReference>
+					<reference value="PractitionerRole/9876543201-046" />
+					<display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras" />
+				</valueReference>
+			</extension>
+			<reference value="Practitioner/2-16-528-1-1007-3-198765432" />
+			<display value="Eduard XXX_Egelinks XXX_Gras" />
+		</individual>
+	</participant>
+	<period>
+		<start value="${DATE, T, D, -76}" />
+	</period>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
 </Encounter>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalObservation792807003-a4907ad5-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalObservation792807003-a4907ad5-2291-11ec-8669-020000000000.xml
@@ -1,37 +1,36 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ad5-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="917b0eb1-a6d9-11ed-1117-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="792807003"/>
-         <display value="Folic acid intake (observable entity)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="29771000146106"/>
-         <display value="intake van foliumzuur via voeding vanaf vastgestelde zwangerschap (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <comment value="op advies verloskundigenpraktijk gestart"/>
+	<id value="a4907ad5-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="917b0eb1-a6d9-11ed-1117-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="792807003" />
+			<display value="Folic acid intake (observable entity)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="29771000146106" />
+			<display value="intake van foliumzuur via voeding vanaf vastgestelde zwangerschap (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<comment value="op advies verloskundigenpraktijk gestart" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalRecord-a490614b-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-MaternalRecord-a490614b-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <EpisodeOfCare xmlns="http://hl7.org/fhir">
-   <id value="a490614b-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9199abb0-a6d9-11ed-2468-020000000000"/>
-   </identifier>
-   <status value="active"/>
-   <type>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364320009"/>
-         <display value="Pregnancy observable (observable entity)"/>
-      </coding>
-   </type>
-   <diagnosis>
-      <condition>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </condition>
-   </diagnosis>
-   <patient>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </patient>
-   <managingOrganization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-106020806"/>
-      <display value="Erasmus MC, Sophia kinderziekenhuis"/>
-   </managingOrganization>
-   <period>
-      <start value="${DATE, T, D, -193}"/>
-   </period>
-   <careManager>
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-         <valueReference>
-            <reference value="PractitionerRole/9876543201-046"/>
-            <display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras"/>
-         </valueReference>
-      </extension>
-      <reference value="Practitioner/2-16-528-1-1007-3-198765432"/>
-      <display value="Eduard XXX_Egelinks XXX_Gras"/>
-   </careManager>
+	<id value="a490614b-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalRecord" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9199abb0-a6d9-11ed-2468-020000000000" />
+	</identifier>
+	<status value="active" />
+	<type>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364320009" />
+			<display value="observatie betreffende zwangerschap (waarneembare entiteit)" />
+		</coding>
+	</type>
+	<diagnosis>
+		<condition>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</condition>
+	</diagnosis>
+	<patient>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</patient>
+	<managingOrganization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-106020806" />
+		<display value="Erasmus MC, Sophia kinderziekenhuis" />
+	</managingOrganization>
+	<period>
+		<start value="${DATE, T, D, -193}" />
+	</period>
+	<careManager>
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+			<valueReference>
+				<reference value="PractitionerRole/9876543201-046" />
+				<display value="Gynaecoloog Eduard XXX_Egelinks XXX_Gras" />
+			</valueReference>
+		</extension>
+		<reference value="Practitioner/2-16-528-1-1007-3-198765432" />
+		<display value="Eduard XXX_Egelinks XXX_Gras" />
+	</careManager>
 </EpisodeOfCare>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure243140006-a4907b3f-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure243140006-a4907b3f-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b3f-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="91dc1008-a6d9-11ed-3745-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000"/>
-      <display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="243140006"/>
-         <display value="inflatie van long door intermitterende compressie van reservoirballon"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}T14:52:00+02:00"/>
-   </performedPeriod>
+	<id value="a4907b3f-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="91dc1008-a6d9-11ed-3745-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000" />
+		<display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="243140006" />
+			<display value="inflatie van long door intermitterende compressie van reservoirballon" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}T14:52:00+02:00" />
+	</performedPeriod>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure32485007-a4907b0c-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure32485007-a4907b0c-2291-11ec-8669-020000000000.xml
@@ -1,46 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b0c-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="91ba9f17-a6d9-11ed-1953-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="32485007"/>
-         <display value="opname in ziekenhuis (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="a4907b0c-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="91ba9f17-a6d9-11ed-1953-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="32485007" />
+			<display value="opname in ziekenhuis (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure396550006-a4907b09-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure396550006-a4907b09-2291-11ec-8669-020000000000.xml
@@ -1,46 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b09-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="91fdbf82-a6d9-11ed-1432-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000"/>
-      <display value="bevalling zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="396550006"/>
-         <display value="bloedonderzoek (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -193}"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </reasonReference>
+	<id value="a4907b09-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="91fdbf82-a6d9-11ed-1432-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b0f-2291-11ec-8669-020000000000" />
+		<display value="bevalling zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="396550006" />
+			<display value="bloedonderzoek (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -193}" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b28-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b28-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b28-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="926d693d-a6d9-11ed-4631-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b11-2291-11ec-8669-020000000000"/>
-      <display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="698350008:370131001=133933007"/>
-         <display value="Administration of vitamin K1 via oral route where Recipient category = Newborn"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}T14:50:00+02:00"/>
-   </performedPeriod>
+	<id value="a4907b28-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="926d693d-a6d9-11ed-4631-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b11-2291-11ec-8669-020000000000" />
+		<display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="698350008:370131001=133933007" />
+			<display value="Administration of vitamin K1 via oral route where Recipient category = Newborn" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}T14:50:00+02:00" />
+	</performedPeriod>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b42-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure698350008370131001=133933007-a4907b42-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b42-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="928e8f66-a6d9-11ed-1541-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000"/>
-      <display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="698350008:370131001=133933007"/>
-         <display value="Administration of vitamin K1 via oral route where Recipient category = Newborn"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}T14:55:00+02:00"/>
-   </performedPeriod>
+	<id value="a4907b42-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="928e8f66-a6d9-11ed-1541-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000" />
+		<display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="698350008:370131001=133933007" />
+			<display value="Administration of vitamin K1 via oral route where Recipient category = Newborn" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}T14:55:00+02:00" />
+	</performedPeriod>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b22-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b22-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b22-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="92219510-a6d9-11ed-1976-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b11-2291-11ec-8669-020000000000"/>
-      <display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="80771000146107"/>
-         <display value="primaire sectio caesarea (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}T14:03:00+02:00"/>
-      <end value="${DATE, T, D, -5}T14:52:00+02:00"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/a4907b03-2291-11ec-8669-020000000000"/>
-      <display value="probleem zwangerschapVrouw2"/>
-   </reasonReference>
+	<id value="a4907b22-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="92219510-a6d9-11ed-1976-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b11-2291-11ec-8669-020000000000" />
+		<display value="uitdrijvingsfase kind2 Jusef zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="80771000146107" />
+			<display value="primaire sectio caesarea (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}T14:03:00+02:00" />
+		<end value="${DATE, T, D, -5}T14:52:00+02:00" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/a4907b03-2291-11ec-8669-020000000000" />
+		<display value="probleem zwangerschapVrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b39-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-ObstetricProcedure80771000146107-a4907b39-2291-11ec-8669-020000000000.xml
@@ -1,46 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Procedure xmlns="http://hl7.org/fhir">
-   <id value="a4907b39-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="924a0a23-a6d9-11ed-1662-020000000000"/>
-   </identifier>
-   <partOf>
-      <reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000"/>
-      <display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2"/>
-   </partOf>
-   <status value="completed"/>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="386637004"/>
-         <display value="Obstetric procedure (procedure)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="80771000146107"/>
-         <display value="primaire sectio caesarea (verrichting)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <performedPeriod>
-      <start value="${DATE, T, D, -5}T14:03:00+02:00"/>
-   </performedPeriod>
-   <reasonReference>
-      <reference value="Condition/a4907b03-2291-11ec-8669-020000000000"/>
-      <display value="probleem zwangerschapVrouw2"/>
-   </reasonReference>
+	<id value="a4907b39-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-ObstetricProcedure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="924a0a23-a6d9-11ed-1662-020000000000" />
+	</identifier>
+	<partOf>
+		<reference value="Procedure/a4907b2b-2291-11ec-8669-020000000000" />
+		<display value="uitdrijvingsfase kind3 Jamal zwangerschap 1 Vrouw2" />
+	</partOf>
+	<status value="completed" />
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="386637004" />
+			<display value="obstetrische verrichting (verrichting)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="80771000146107" />
+			<display value="primaire sectio caesarea (verrichting)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<performedPeriod>
+		<start value="${DATE, T, D, -5}T14:03:00+02:00" />
+	</performedPeriod>
+	<reasonReference>
+		<reference value="Condition/a4907b03-2291-11ec-8669-020000000000" />
+		<display value="probleem zwangerschapVrouw2" />
+	</reasonReference>
 </Procedure>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2191-11ec-8667-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2191-11ec-8667-030000000000.xml
@@ -1,39 +1,39 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bc6-2191-11ec-8667-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bc6-2291-11ec-8667-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -19}"/>
-    <valueQuantity>
-        <value value="259" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bc6-2191-11ec-8667-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bc6-2291-11ec-8667-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -19}" />
+	<valueQuantity>
+		<value value="259" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2195-11ec-8667-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2195-11ec-8667-030000000000.xml
@@ -1,45 +1,45 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bc6-2195-11ec-8667-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
-        <valueReference>
-            <reference value="Condition/a4907b00-2291-11ec-8669-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2 meerlingzwangerschap (aandoening)"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bc6-2295-11ec-8667-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -207}"/>
-    <valueQuantity>
-        <value value="71" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bc6-2195-11ec-8667-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
+		<valueReference>
+			<reference value="Condition/a4907b00-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2 meerlingzwangerschap (aandoening)" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bc6-2295-11ec-8667-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -207}" />
+	<valueQuantity>
+		<value value="71" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2195-12ec-8667-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-Pregnancy-PregnancyDuration57036006-a4907bc6-2195-12ec-8667-030000000000.xml
@@ -1,45 +1,45 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="a4907bc6-2195-12ec-8667-030000000000" />
-    <meta>
-        <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
-        <valueReference>
-            <reference value="Condition/a4907b03-2291-11ec-8669-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2 intra-uteriene groeiretardatie (aandoening)"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-        <value value="a4907bc6-2195-12ec-8667-030000000000"/>
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="57036006" />
-            <display value="Fetal gestational age" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <effectiveDateTime value="${DATE, T, D, -90}"/>
-    <valueQuantity>
-        <value value="188" />
-        <system value="http://unitsofmeasure.org" />
-        <code value="d" />
-    </valueQuantity>
+	<id value="a4907bc6-2195-12ec-8667-030000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-Pregnancy-PregnancyDuration" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3">
+		<valueReference>
+			<reference value="Condition/a4907b03-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2 intra-uteriene groeiretardatie (aandoening)" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="a4907bc6-2195-12ec-8667-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="57036006" />
+			<display value="Fetal gestational age" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/66aa2fcb-2064-11ec-5265-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -90}" />
+	<valueQuantity>
+		<value value="188" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="d" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation143881000146107-a4907ad1-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation143881000146107-a4907ad1-2291-11ec-8669-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ad1-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9332f0ea-a6d9-11ed-1399-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="143881000146107"/>
-         <display value="aantal levende nakomelingen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -76}"/>
-   <valueQuantity>
-      <value value="2"/>
-   </valueQuantity>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="278292003"/>
-         <display value="echografische beeldvorming (kwalificatiewaarde)"/>
-      </coding>
-   </method>
+	<id value="a4907ad1-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9332f0ea-a6d9-11ed-1399-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="143881000146107" />
+			<display value="aantal levende nakomelingen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -76}" />
+	<valueQuantity>
+		<value value="2" />
+	</valueQuantity>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="278292003" />
+			<display value="echografische beeldvorming (kwalificatiewaarde)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation147781000146105-a49075b0-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation147781000146105-a49075b0-2291-11ec-8669-020000000000.xml
@@ -1,43 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49075b0-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9355280e-a6d9-11ed-1746-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="147781000146105"/>
-         <display value="definitieve uitgerekende datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -126}T13:45:00+02:00"/>
-   <valueDateTime value="${DATE, T, D, +2}"/>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="278292003"/>
-         <display value="echografische beeldvorming (kwalificatiewaarde)"/>
-      </coding>
-   </method>
+	<id value="a49075b0-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9355280e-a6d9-11ed-1746-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="147781000146105" />
+			<display value="definitieve uitgerekende datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -126}T13:45:00+02:00" />
+	<valueDateTime value="${DATE, T, D, +2}" />
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="278292003" />
+			<display value="echografische beeldvorming (kwalificatiewaarde)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation161714006-a49075ab-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation161714006-a49075ab-2291-11ec-8669-020000000000.xml
@@ -1,44 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49075ab-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="92cef6e9-a6d9-11ed-1795-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161714006"/>
-         <display value="geschatte datum van partus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -205}"/>
-   <valueDateTime value="${DATE, T, D, +10}"/>
-   <method>
-      <coding>
-         <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
-         <code value="OTH"/>
-         <display value="Anders"/>
-      </coding>
-      <text value="uit verwijzing verloskundigenpraktijk"/>
-   </method>
+	<id value="a49075ab-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="92cef6e9-a6d9-11ed-1795-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161714006" />
+			<display value="geschatte datum van partus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -205}" />
+	<valueDateTime value="${DATE, T, D, +10}" />
+	<method>
+		<coding>
+			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
+			<code value="OTH" />
+			<display value="Anders" />
+		</coding>
+		<text value="uit verwijzing verloskundigenpraktijk" />
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation246435002-a49075b4-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation246435002-a49075b4-2291-11ec-8669-020000000000.xml
@@ -1,45 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49075b4-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="92ed8d6e-a6d9-11ed-1354-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="246435002"/>
-         <display value="aantal foetussen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}"/>
-   <valueQuantity>
-      <value value="2"/>
-   </valueQuantity>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="278292003"/>
-         <display value="echografische beeldvorming (kwalificatiewaarde) "/>
-      </coding>
-   </method>
+	<id value="a49075b4-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="92ed8d6e-a6d9-11ed-1354-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="246435002" />
+			<display value="aantal foetussen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}" />
+	<valueQuantity>
+		<value value="2" />
+	</valueQuantity>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="278292003" />
+			<display value="echografische beeldvorming (kwalificatiewaarde) " />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation364618000-a4907ade-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation364618000-a4907ade-2291-11ec-8669-020000000000.xml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ade-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9310ae28-a6d9-11ed-3827-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364618000"/>
-         <display value="bewegingspatroon van foetus (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}T13:40:00+02:00"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="289431008"/>
-         <display value="foetale bewegingen aanwezig (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="113011001"/>
-         <display value="palpatie (verrichting)"/>
-      </coding>
-   </method>
+	<id value="a4907ade-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9310ae28-a6d9-11ed-3827-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364618000" />
+			<display value="bewegingspatroon van foetus (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}T13:40:00+02:00" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="289431008" />
+			<display value="foetale bewegingen aanwezig (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="113011001" />
+			<display value="palpatie (verrichting)" />
+		</coding>
+	</method>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation65147003-a4907acc-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-bc-PregnancyObservation65147003-a4907acc-2291-11ec-8669-020000000000.xml
@@ -1,56 +1,55 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907acc-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="92b05bfd-a6d9-11ed-3170-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="65147003"/>
-         <display value="tweelingzwangerschap (aandoening)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="459168005"/>
-         <display value="monochoriale diamniotische tweelingzwangerschap (aandoening)"/>
-      </coding>
-   </valueCodeableConcept>
-   <method>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="278292003"/>
-         <display value="echografische beeldvorming (kwalificatiewaarde)"/>
-      </coding>
-   </method>
-   <related>
-      <type value="derived-from"/>
-      <target>
-         <reference value="Observation/a49075b4-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2 aantal foetussen"/>
-      </target>
-   </related>
+	<id value="a4907acc-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/bc-PregnancyObservation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="92b05bfd-a6d9-11ed-3170-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="65147003" />
+			<display value="tweelingzwangerschap (aandoening)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="459168005" />
+			<display value="monochoriale diamniotische tweelingzwangerschap (aandoening)" />
+		</coding>
+	</valueCodeableConcept>
+	<method>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="278292003" />
+			<display value="echografische beeldvorming (kwalificatiewaarde)" />
+		</coding>
+	</method>
+	<related>
+		<type value="derived-from" />
+		<target>
+			<reference value="Observation/a49075b4-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2 aantal foetussen" />
+		</target>
+	</related>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-organization-2-16-840-1-113883-2-4-6-106020806.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-organization-2-16-840-1-113883-2-4-6-106020806.xml
@@ -1,72 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Organization xmlns="http://hl7.org/fhir">
-   <id value="2-16-840-1-113883-2-4-6-106020806"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-organization"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>OrganisatieId: 06020806 (AGB-Z)</caption>
-            <tbody>
-               <tr>
-                  <th>Naam</th>
-                  <td>Erasmus MC, Sophia kinderziekenhuis</td>
-               </tr>
-               <tr>
-                  <th>Type</th>
-                  <td>
-                     <span title="Universitair Medisch Centrum (V5 - RoleCodeNL Zorgaanbiedertype)">Universitair Medisch Centrum</span>
-                  </td>
-               </tr>
-               <tr>
-                  <th>Adres</th>
-                  <td>Dr. Molewaterplein 60, 3015GJ ROTTERDAM (Werk)</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="http://fhir.nl/fhir/NamingSystem/agb-z"/>
-      <value value="06020806"/>
-   </identifier>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="937d7ac0-a6d9-11ed-1386-020000000000"/>
-   </identifier>
-   <type>
-      <coding>
-         <system value="http://nictiz.nl/fhir/NamingSystem/organization-type"/>
-         <version value="2020-11-11T00:00:00"/>
-         <code value="V5"/>
-         <display value="Universitair Medisch Centrum"/>
-      </coding>
-   </type>
-   <name value="Erasmus MC, Sophia kinderziekenhuis"/>
-   <address>
-      <use value="work"/>
-      <line value="Dr. Molewaterplein 60">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Dr. Molewaterplein"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="60"/>
-         </extension>
-      </line>
-      <city value="ROTTERDAM"/>
-      <postalCode value="3015GJ"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
+	<id value="2-16-840-1-113883-2-4-6-106020806" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-organization" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>OrganisatieId: 06020806 (AGB-Z)</caption>
+				<tbody>
+					<tr>
+						<th>Naam</th>
+						<td>Erasmus MC, Sophia kinderziekenhuis</td>
+					</tr>
+					<tr>
+						<th>Type</th>
+						<td>
+							<span title="Universitair Medisch Centrum (V5 - RoleCodeNL Zorgaanbiedertype)">Universitair Medisch Centrum</span>
+						</td>
+					</tr>
+					<tr>
+						<th>Adres</th>
+						<td>Dr. Molewaterplein 60, 3015GJ ROTTERDAM (Werk)</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="http://fhir.nl/fhir/NamingSystem/agb-z" />
+		<value value="06020806" />
+	</identifier>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="937d7ac0-a6d9-11ed-1386-020000000000" />
+	</identifier>
+	<type>
+		<coding>
+			<system value="http://nictiz.nl/fhir/NamingSystem/organization-type" />
+			<version value="2020-11-11T00:00:00" />
+			<code value="V5" />
+			<display value="Universitair Medisch Centrum" />
+		</coding>
+	</type>
+	<name value="Erasmus MC, Sophia kinderziekenhuis" />
+	<address>
+		<use value="work" />
+		<line value="Dr. Molewaterplein 60">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Dr. Molewaterplein" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="60" />
+			</extension>
+		</line>
+		<city value="ROTTERDAM" />
+		<postalCode value="3015GJ" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
 </Organization>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-patient-JAMALJXXX-KWEE.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-patient-JAMALJXXX-KWEE.xml
@@ -1,61 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="JAMALJXXX-KWEE"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Jamal J XXX_Kwee, Man, ${DATE, T, D, -5}, Meerling</div>
-         <div>Knolweg 1000, 9999XA STITSWERD ()</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="939ed6bc-a6d9-11ed-1705-020000000000"/>
-   </identifier>
-   <name>
-      <family value="XXX_Kwee">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Kwee"/>
-         </extension>
-      </family>
-      <given value="Jamal">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="J">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="male"/>
-   <birthDate value="${DATE, T, D, -5}"/>
-   <address>
-      <line value="Knolweg 1000">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1000"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999XA"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
-   <multipleBirthInteger value="2"/>
+	<id value="JAMALJXXX-KWEE" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Jamal J XXX_Kwee, Man, ${DATE, T, D, -5}, Meerling</div>
+			<div>Knolweg 1000, 9999XA STITSWERD ()</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="939ed6bc-a6d9-11ed-1705-020000000000" />
+	</identifier>
+	<name>
+		<family value="XXX_Kwee">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Kwee" />
+			</extension>
+		</family>
+		<given value="Jamal">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="J">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="male" />
+	<birthDate value="${DATE, T, D, -5}" />
+	<address>
+		<line value="Knolweg 1000">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1000" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999XA" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
+	<multipleBirthInteger value="2" />
 </Patient>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-patient-JUSEFJXXX-KWEE.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-patient-JUSEFJXXX-KWEE.xml
@@ -1,61 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="JUSEFJXXX-KWEE"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Jusef J XXX_Kwee, Man, ${DATE, T, D, -5}, Meerling</div>
-         <div>Knolweg 1000, 9999XA STITSWERD ()</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="93dc6272-a6d9-11ed-1928-020000000000"/>
-   </identifier>
-   <name>
-      <family value="XXX_Kwee">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Kwee"/>
-         </extension>
-      </family>
-      <given value="Jusef">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="J">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="male"/>
-   <birthDate value="${DATE, T, D, -5}"/>
-   <address>
-      <line value="Knolweg 1000">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1000"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999XA"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:iso:std:iso:3166"/>
-                  <code value="NL"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
-   <multipleBirthInteger value="1"/>
+	<id value="JUSEFJXXX-KWEE" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Jusef J XXX_Kwee, Man, ${DATE, T, D, -5}, Meerling</div>
+			<div>Knolweg 1000, 9999XA STITSWERD ()</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="93dc6272-a6d9-11ed-1928-020000000000" />
+	</identifier>
+	<name>
+		<family value="XXX_Kwee">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Kwee" />
+			</extension>
+		</family>
+		<given value="Jusef">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="J">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="male" />
+	<birthDate value="${DATE, T, D, -5}" />
+	<address>
+		<line value="Knolweg 1000">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1000" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999XA" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:iso:std:iso:3166" />
+						<code value="NL" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
+	<multipleBirthInteger value="1" />
 </Patient>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-practitionerrole-9876543201-046.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-nl-core-practitionerrole-9876543201-046.xml
@@ -1,51 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <PractitionerRole xmlns="http://hl7.org/fhir">
-   <id value="9876543201-046"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-practitionerrole"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Zorgverlenerrol</caption>
-            <tbody>
-               <tr>
-                  <th>Zorgverlener</th>
-                  <td>
-                     <div>
-                        <a href="Practitioner/2-16-528-1-1007-3-198765432">Eduard XXX_Egelinks XXX_Gras</a>
-                     </div>
-                  </td>
-               </tr>
-               <tr>
-                  <th>Specialisme</th>
-                  <td>
-                     <span title="Gynaecoloog (01.046 - http://fhir.nl/fhir/NamingSystem/uzi-rolcode)">Gynaecoloog</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="941f51cd-a6d9-11ed-1492-020000000000"/>
-   </identifier>
-   <practitioner>
-      <reference value="Practitioner/2-16-528-1-1007-3-198765432"/>
-      <display value="Eduard XXX_Egelinks XXX_Gras"/>
-   </practitioner>
-   <organization>
-      <reference value="Organization/2-16-840-1-113883-2-4-6-106020806"/>
-      <display value="Erasmus MC, Sophia kinderziekenhuis"/>
-   </organization>
-   <specialty>
-      <coding>
-         <system value="http://fhir.nl/fhir/NamingSystem/uzi-rolcode"/>
-         <version value="2020-04-01T00:00:00"/>
-         <code value="01.046"/>
-         <display value="Gynaecoloog"/>
-      </coding>
-   </specialty>
+	<id value="9876543201-046" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-practitionerrole" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Zorgverlenerrol</caption>
+				<tbody>
+					<tr>
+						<th>Zorgverlener</th>
+						<td>
+							<div>
+								<a href="Practitioner/2-16-528-1-1007-3-198765432">Eduard XXX_Egelinks XXX_Gras</a>
+							</div>
+						</td>
+					</tr>
+					<tr>
+						<th>Specialisme</th>
+						<td>
+							<span title="Gynaecoloog (01.046 - http://fhir.nl/fhir/NamingSystem/uzi-rolcode)">Gynaecoloog</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="941f51cd-a6d9-11ed-1492-020000000000" />
+	</identifier>
+	<practitioner>
+		<reference value="Practitioner/2-16-528-1-1007-3-198765432" />
+		<display value="Eduard XXX_Egelinks XXX_Gras" />
+	</practitioner>
+	<organization>
+		<reference value="Organization/2-16-840-1-113883-2-4-6-106020806" />
+		<display value="Erasmus MC, Sophia kinderziekenhuis" />
+	</organization>
+	<specialty>
+		<coding>
+			<system value="http://fhir.nl/fhir/NamingSystem/uzi-rolcode" />
+			<version value="2020-04-01T00:00:00" />
+			<code value="01.046" />
+			<display value="Gynaecoloog" />
+		</coding>
+	</specialty>
 </PractitionerRole>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-AlcoholUse228273003-a4907ae3-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-AlcoholUse228273003-a4907ae3-2291-11ec-8669-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ae3-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="943defa6-a6d9-11ed-2125-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228273003"/>
-         <display value="bevinding betreffende alcoholgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="105542008"/>
-         <display value="drinkt momenteel geen alcohol (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4907ae3-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AlcoholUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="943defa6-a6d9-11ed-2125-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228273003" />
+			<display value="bevinding betreffende alcoholgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="105542008" />
+			<display value="drinkt momenteel geen alcohol (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9271-8-a4907b62-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9271-8-a4907b62-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b62-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="945fc553-a6d9-11ed-1639-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9271-8"/>
-         <display value="10 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="10"/>
-   </valueQuantity>
+	<id value="a4907b62-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="945fc553-a6d9-11ed-1639-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9271-8" />
+			<display value="10 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="10" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9271-8-a4907b80-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9271-8-a4907b80-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b80-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="94844761-a6d9-11ed-1075-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9271-8"/>
-         <display value="10 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="10"/>
-   </valueQuantity>
+	<id value="a4907b80-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="94844761-a6d9-11ed-1075-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9271-8" />
+			<display value="10 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="10" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9272-6-a4907b5e-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9272-6-a4907b5e-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b5e-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="94ae6e16-a6d9-11ed-1377-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9272-6"/>
-         <display value="1 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="7"/>
-   </valueQuantity>
+	<id value="a4907b5e-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="94ae6e16-a6d9-11ed-1377-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9272-6" />
+			<display value="1 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="7" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9272-6-a4907b7c-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9272-6-a4907b7c-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b7c-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="94d3a78e-a6d9-11ed-7299-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9272-6"/>
-         <display value="1 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="5"/>
-   </valueQuantity>
+	<id value="a4907b7c-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="94d3a78e-a6d9-11ed-7299-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9272-6" />
+			<display value="1 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="5" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9274-2-a4907b60-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9274-2-a4907b60-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b60-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="951acb29-a6d9-11ed-6461-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9274-2"/>
-         <display value="5 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="10"/>
-   </valueQuantity>
+	<id value="a4907b60-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="951acb29-a6d9-11ed-6461-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9274-2" />
+			<display value="5 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="10" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9274-2-a4907b7e-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-ApgarScore9274-2-a4907b7e-2291-11ec-8669-020000000000.xml
@@ -1,32 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b7e-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="94f7e5ee-a6d9-11ed-2131-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9274-2"/>
-         <display value="5 minute Apgar Score"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="9"/>
-   </valueQuantity>
+	<id value="a4907b7e-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ApgarScore" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="94f7e5ee-a6d9-11ed-2131-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9274-2" />
+			<display value="5 minute Apgar Score" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="9" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907ba9-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907ba9-2291-11ec-8669-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ba9-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="953ca58e-a6d9-11ed-2087-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="123"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="81"/>
-      </valueQuantity>
-   </component>
+	<id value="a4907ba9-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="953ca58e-a6d9-11ed-2087-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="123" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="81" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907bb1-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907bb1-2291-11ec-8669-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907bb1-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="955d2da3-a6d9-11ed-1361-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907afa-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-76D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -76}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="108"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="79"/>
-      </valueQuantity>
-   </component>
+	<id value="a4907bb1-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="955d2da3-a6d9-11ed-1361-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907afa-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-76D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -76}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="108" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="79" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907bb6-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BloodPressure85354-9-a4907bb6-2291-11ec-8669-020000000000.xml
@@ -1,60 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907bb6-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="957f25bd-a6d9-11ed-7546-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="85354-9"/>
-         <display value="Blood pressure panel with all children optional"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/66aa521d-2064-11ec-5265-020000000000"/>
-      <display value="prenatale controle T-5D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8480-6"/>
-            <display value="Systolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="91"/>
-      </valueQuantity>
-   </component>
-   <component>
-      <code>
-         <coding>
-            <system value="http://loinc.org"/>
-            <code value="8462-4"/>
-            <display value="Diastolic blood pressure"/>
-         </coding>
-      </code>
-      <valueQuantity>
-         <value value="57"/>
-      </valueQuantity>
-   </component>
+	<id value="a4907bb6-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BloodPressure" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="957f25bd-a6d9-11ed-7546-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display value="Blood pressure panel with all children optional" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/66aa521d-2064-11ec-5265-020000000000" />
+		<display value="prenatale controle T-5D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="91" />
+		</valueQuantity>
+	</component>
+	<component>
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="57" />
+		</valueQuantity>
+	</component>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyHeight89269-5-a4907b58-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyHeight89269-5-a4907b58-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b58-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="95a025cc-a6d9-11ed-1431-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8302-2"/>
-         <display value="Body height"/>
-      </coding>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="89269-5"/>
-         <display value="Body height Measured --at birth"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="48"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="a4907b58-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="95a025cc-a6d9-11ed-1431-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8302-2" />
+			<display value="Body height" />
+		</coding>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="89269-5" />
+			<display value="Body height Measured --at birth" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="48" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyHeight89269-5-a4907b76-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyHeight89269-5-a4907b76-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b76-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="95c5e8c0-a6d9-11ed-1354-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8302-2"/>
-         <display value="Body height"/>
-      </coding>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="89269-5"/>
-         <display value="Body height Measured --at birth"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="46"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="a4907b76-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyHeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="95c5e8c0-a6d9-11ed-1354-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8302-2" />
+			<display value="Body height" />
+		</coding>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="89269-5" />
+			<display value="Body height Measured --at birth" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="46" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyWeight29463-7-a4907bae-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-BodyWeight29463-7-a4907bae-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907bae-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="95ecf1c1-a6d9-11ed-1888-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="29463-7"/>
-         <display value="Body weight"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -193}"/>
-   <valueQuantity>
-      <value value="65"/>
-      <unit value="kg"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="kg"/>
-   </valueQuantity>
+	<id value="a4907bae-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-BodyWeight" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="95ecf1c1-a6d9-11ed-1888-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="29463-7" />
+			<display value="Body weight" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -193}" />
+	<valueQuantity>
+		<value value="65" />
+		<unit value="kg" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="kg" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-DrugUse228366006-a4907ae5-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-DrugUse228366006-a4907ae5-2291-11ec-8669-020000000000.xml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ae5-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9611db48-a6d9-11ed-1965-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228366006"/>
-         <display value="bevinding betreffende drugsgebruik (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="228368007"/>
-         <display value="heeft nooit drugs gebruikt"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4907ae5-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-DrugUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9611db48-a6d9-11ed-1965-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228366006" />
+			<display value="bevinding betreffende drugsgebruik (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="228368007" />
+			<display value="heeft nooit drugs gebruikt" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-HeadCircumference169876006-a4907b5a-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-HeadCircumference169876006-a4907b5a-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b5a-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="96339bec-a6d9-11ed-1608-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9843-4"/>
-         <display value="Head Occipital-frontal circumference"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169876006"/>
-         <display value=" hoofdomtrek bij geboorte (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JUSEFJXXX-KWEE"/>
-      <display value="Jusef J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="32.6"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="a4907b5a-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="96339bec-a6d9-11ed-1608-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9843-4" />
+			<display value="Head Occipital-frontal circumference" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169876006" />
+			<display value=" hoofdomtrek bij geboorte (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JUSEFJXXX-KWEE" />
+		<display value="Jusef J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="32.6" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-HeadCircumference169876006-a4907b78-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-HeadCircumference169876006-a4907b78-2291-11ec-8669-020000000000.xml
@@ -1,47 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907b78-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="966078a4-a6d9-11ed-6579-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <category>
-      <coding>
-         <system value="http://hl7.org/fhir/observation-category"/>
-         <code value="vital-signs"/>
-         <display value="Vital Signs"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="9843-4"/>
-         <display value="Head Occipital-frontal circumference"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="169876006"/>
-         <display value=" hoofdomtrek bij geboorte (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMALJXXX-KWEE"/>
-      <display value="Jamal J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="${DATE, T, D, -5}"/>
-   <valueQuantity>
-      <value value="31.8"/>
-      <unit value="cm"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="cm"/>
-   </valueQuantity>
+	<id value="a4907b78-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-HeadCircumference" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="966078a4-a6d9-11ed-6579-020000000000" />
+	</identifier>
+	<status value="final" />
+	<category>
+		<coding>
+			<system value="http://hl7.org/fhir/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="9843-4" />
+			<display value="Head Occipital-frontal circumference" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="169876006" />
+			<display value=" hoofdomtrek bij geboorte (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMALJXXX-KWEE" />
+		<display value="Jamal J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="${DATE, T, D, -5}" />
+	<valueQuantity>
+		<value value="31.8" />
+		<unit value="cm" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="cm" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-a4906e60-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1159-3-a4906e60-2291-11ec-8669-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4906e60-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-22</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
-                  </td>
-                  <td>
-                     <span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="96a84356-a6d9-11ed-1126-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1159-3"/>
-         <display value="little c Ag [Presence] on Red Blood Cells"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-22"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="733120009"/>
-         <display value="Rhc-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4906e60-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-22</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="little c Ag [Presence] on Red Blood Cells (1159-3 - LOINC)">little c Ag [Presence] on Red Blood Cells</span>
+						</td>
+						<td>
+							<span title="Rhc-positief (733120009 - SNOMED CT)">Rh c Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="96a84356-a6d9-11ed-1126-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1159-3" />
+			<display value="little c Ag [Presence] on Red Blood Cells" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-22" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="733120009" />
+			<display value="fenotype c-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-a4906c9e-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation1305-2-a4906c9e-2291-11ec-8669-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4906c9e-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-22</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="96ca4c33-a6d9-11ed-8668-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="1305-2"/>
-         <display value="D Ag [Presence] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-22"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="165747007"/>
-         <display value="RhD-positief"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4906c9e-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-22</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="D Ag [Presence] in Blood (1305-2 - LOINC)">D Ag [Presence] in Blood</span>
+						</td>
+						<td>
+							<span title="RhD-positief (165747007 - SNOMED CT)">Rh D Positief</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="96ca4c33-a6d9-11ed-8668-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="1305-2" />
+			<display value="D Ag [Presence] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-22" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="165747007" />
+			<display value="fenotype D-positief (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation8039-0-a49071d0-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation8039-0-a49071d0-2291-11ec-8669-020000000000.xml
@@ -1,75 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49071d0-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-22</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="Toxoplasma gondii IgG Ab [Units/volume] in Serum (8039-0 - LOINC)">Toxoplasma gondii IgG Ab [Units/volume] in Serum</span>
-                  </td>
-                  <td>9 k[arb'U]/L</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="96f1befe-a6d9-11ed-2078-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="8039-0"/>
-         <display value="Toxoplasma gondii IgG Ab [Units/volume] in Serum"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-22"/>
-   <valueQuantity>
-      <value value="9"/>
-      <unit value="k[arb'U]/L"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="k[arb'U]/L"/>
-   </valueQuantity>
+	<id value="a49071d0-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-22</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Toxoplasma gondii IgG Ab [Units/volume] in Serum (8039-0 - LOINC)">Toxoplasma gondii IgG Ab [Units/volume] in Serum</span>
+						</td>
+						<td>9 k[arb'U]/L</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="96f1befe-a6d9-11ed-2078-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="8039-0" />
+			<display value="Toxoplasma gondii IgG Ab [Units/volume] in Serum" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-22" />
+	<valueQuantity>
+		<value value="9" />
+		<unit value="k[arb'U]/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="k[arb'U]/L" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-a4906adc-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation883-9-a4906adc-2291-11ec-8669-020000000000.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4906adc-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-22</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
-                  </td>
-                  <td>
-                     <span title="bloedgroep O (bevinding) (58460004 - SNOMED CT)">bloedgroep O (bevinding)</span>
-                  </td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9685aade-a6d9-11ed-9352-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="883-9"/>
-         <display value="ABO group [Type] in Blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-22"/>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="58460004"/>
-         <display value="bloedgroep O (bevinding)"/>
-      </coding>
-   </valueCodeableConcept>
+	<id value="a4906adc-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-22</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="ABO group [Type] in Blood (883-9 - LOINC)">ABO group [Type] in Blood</span>
+						</td>
+						<td>
+							<span title="bloedgroep O (bevinding) (58460004 - SNOMED CT)">bloedgroep O (bevinding)</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9685aade-a6d9-11ed-9352-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="883-9" />
+			<display value="ABO group [Type] in Blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-22" />
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="58460004" />
+			<display value="bloedgroep O (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907022-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907022-2291-11ec-8669-020000000000.xml
@@ -1,75 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907022-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-03-22</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
-                  </td>
-                  <td>7.0 g/dL</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="971b21ae-a6d9-11ed-1444-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="93846-4"/>
-         <display value="Hemoglobin [Moles/volume] in Venous blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-03-22"/>
-   <valueQuantity>
-      <value value="7.0"/>
-      <unit value="g/dL"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g/dL"/>
-   </valueQuantity>
+	<id value="a4907022-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-03-22</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
+						</td>
+						<td>7.0 g/dL</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="971b21ae-a6d9-11ed-1444-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="93846-4" />
+			<display value="Hemoglobin [Moles/volume] in Venous blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-03-22" />
+	<valueQuantity>
+		<value value="7.0" />
+		<unit value="g/dL" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g/dL" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907374-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907374-2291-11ec-8669-020000000000.xml
@@ -1,75 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907374-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-07-17</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
-                  </td>
-                  <td>6.7 g/dL</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="973d14e8-a6d9-11ed-1855-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="93846-4"/>
-         <display value="Hemoglobin [Moles/volume] in Venous blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-07-17"/>
-   <valueQuantity>
-      <value value="6.7"/>
-      <unit value="g/dL"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g/dL"/>
-   </valueQuantity>
+	<id value="a4907374-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-07-17</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
+						</td>
+						<td>6.7 g/dL</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="973d14e8-a6d9-11ed-1855-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="93846-4" />
+			<display value="Hemoglobin [Moles/volume] in Venous blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-07-17" />
+	<valueQuantity>
+		<value value="6.7" />
+		<unit value="g/dL" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g/dL" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907518-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-LaboratoryTestResult-Observation93846-4-a4907518-2291-11ec-8669-020000000000.xml
@@ -1,75 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907518-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <table>
-            <caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
-            <tbody>
-               <tr>
-                  <th>Bepalingdatum/tijd</th>
-                  <td>2021-09-26</td>
-               </tr>
-               <tr>
-                  <th>Code</th>
-                  <th>Waarde</th>
-               </tr>
-               <tr>
-                  <td>
-                     <span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
-                  </td>
-                  <td>6.5 g/dL</td>
-               </tr>
-            </tbody>
-         </table>
-      </div>
-   </text>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="975e119f-a6d9-11ed-6284-020000000000"/>
-   </identifier>
-   <status value="final">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1"/>
-               <code value="final"/>
-               <display value="Final"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </status>
-   <category>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="49581000146104"/>
-         <display value="Laboratory test finding (finding)"/>
-      </coding>
-   </category>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="93846-4"/>
-         <display value="Hemoglobin [Moles/volume] in Venous blood"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <effectiveDateTime value="2021-09-26"/>
-   <valueQuantity>
-      <value value="6.5"/>
-      <unit value="g/dL"/>
-      <system value="http://unitsofmeasure.org"/>
-      <code value="g/dL"/>
-   </valueQuantity>
+	<id value="a4907518-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-LaboratoryTestResult-Observation" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<table>
+				<caption>Observatie/bepaling. Subject: <a href="Patient/JAMILAJXXX-KWEE">Jamila J XXX_Kwee</a>. Categorie: 49581000146104 (SNOMED CT), Status: definitief</caption>
+				<tbody>
+					<tr>
+						<th>Bepalingdatum/tijd</th>
+						<td>2021-09-26</td>
+					</tr>
+					<tr>
+						<th>Code</th>
+						<th>Waarde</th>
+					</tr>
+					<tr>
+						<td>
+							<span title="Hemoglobin [Moles/volume] in Venous blood (93846-4 - LOINC)">Hemoglobin [Moles/volume] in Venous blood</span>
+						</td>
+						<td>6.5 g/dL</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="975e119f-a6d9-11ed-6284-020000000000" />
+	</identifier>
+	<status value="final">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.16.1" />
+					<code value="final" />
+					<display value="Final" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</status>
+	<category>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="49581000146104" />
+			<display value="Laboratory test finding (finding)" />
+		</coding>
+	</category>
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="93846-4" />
+			<display value="Hemoglobin [Moles/volume] in Venous blood" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<effectiveDateTime value="2021-09-26" />
+	<valueQuantity>
+		<value value="6.5" />
+		<unit value="g/dL" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="g/dL" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2019-030000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-DateLastMenstruation21840007-1ca0e1e1-8fdf-11ec-2019-030000000000.xml
@@ -1,33 +1,33 @@
 <Observation xmlns="http://hl7.org/fhir">
-    <id value="1ca0e1e1-8fdf-11ec-2019-030000000000" />
-    <meta>
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
-    </meta>
-    <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-        <valueReference>
-            <reference value="Condition/66aa440b-2064-11ec-5265-020000000000"/>
-            <display value="Zwangerschap 1 Vrouw2"/>
-        </valueReference>
-    </extension>
-    <identifier>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-        <value value="1ca0e1e1-8fdf-11ec-2019-030000000000" />
-    </identifier>
-    <status value="final" />
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="21840007" />
-            <display value="Date of last menstrual period" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/JAMILAJXXX-KWEE"/>
-        <display value="Jamila J XXX_Kwee"/>
-    </subject>
-    <context>
-        <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-        <display value="Zwangerschap 1 Vrouw2"/>
-    </context>
-    <valueDateTime value="${DATE, T, D, -278}" />
+	<id value="1ca0e1e1-8fdf-11ec-2019-030000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-DateLastMenstruation" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/66aa440b-2064-11ec-5265-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="1ca0e1e1-8fdf-11ec-2019-030000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="21840007" />
+			<display value="datum van laatste menstruatie (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueDateTime value="${DATE, T, D, -278}" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-Gravidity161732006-a49075a9-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-Gravidity161732006-a49075a9-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49075a9-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9783a6a7-a6d9-11ed-1897-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11996-6"/>
-         <display value="[#] Pregnancies"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="161732006"/>
-         <display value="aantal zwangerschappen (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="a49075a9-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Gravidity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="9783a6a7-a6d9-11ed-1897-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11996-6" />
+			<display value="[#] Pregnancies" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="161732006" />
+			<display value="aantal zwangerschappen (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-Parity364325004-a49075a8-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy-Parity364325004-a49075a8-2291-11ec-8669-020000000000.xml
@@ -1,42 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a49075a8-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity"/>
-   </meta>
-   <extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
-      <valueReference>
-         <reference value="Condition/a49075a7-2291-11ec-8669-020000000000"/>
-         <display value="Zwangerschap 1 Vrouw2"/>
-      </valueReference>
-   </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="97a6733c-a6d9-11ed-2093-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://loinc.org"/>
-         <code value="11977-6"/>
-         <display value="[#] Parity"/>
-      </coding>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="364325004"/>
-         <display value="pariteit (waarneembare entiteit)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
-   <valueQuantity>
-      <value value="1"/>
-   </valueQuantity>
+	<id value="a49075a8-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy-Parity" />
+	</meta>
+	<extension url="http://nictiz.nl/fhir/StructureDefinition/observation-focusSTU3">
+		<valueReference>
+			<reference value="Condition/a49075a7-2291-11ec-8669-020000000000" />
+			<display value="Zwangerschap 1 Vrouw2" />
+		</valueReference>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="97a6733c-a6d9-11ed-2093-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="11977-6" />
+			<display value="[#] Parity" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="364325004" />
+			<display value="pariteit (waarneembare entiteit)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
+	<valueQuantity>
+		<value value="1" />
+	</valueQuantity>
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy118185001-a49075a7-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-Pregnancy118185001-a49075a7-2291-11ec-8669-020000000000.xml
@@ -1,27 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-   <id value="a49075a7-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="97c9b85e-a6d9-11ed-1769-020000000000"/>
-   </identifier>
-   <clinicalStatus value="active"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="118185001"/>
-         <display value="Finding related to pregnancy (finding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000"/>
-      <display value="Zwangerschap 1 Vrouw2"/>
-   </context>
+	<id value="a49075a7-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Pregnancy" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="97c9b85e-a6d9-11ed-1769-020000000000" />
+	</identifier>
+	<clinicalStatus value="active" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="118185001" />
+			<display value="bevinding betreffende zwangerschap (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="EpisodeOfCare/a490614b-2291-11ec-8669-020000000000" />
+		<display value="Zwangerschap 1 Vrouw2" />
+	</context>
 </Condition>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-TobaccoUse365980008-a4907ae9-2291-11ec-8669-020000000000.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw2-Kaart3-2elijn/medmij-gbz-zib-TobaccoUse365980008-a4907ae9-2291-11ec-8669-020000000000.xml
@@ -1,56 +1,55 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-   <id value="a4907ae9-2291-11ec-8669-020000000000"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation"/>
-      <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse"/>
-   </meta>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="97ea1e41-a6d9-11ed-2072-020000000000"/>
-   </identifier>
-   <status value="final"/>
-   <code>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="365980008"/>
-         <display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)"/>
-      </coding>
-   </code>
-   <subject>
-      <reference value="Patient/JAMILAJXXX-KWEE"/>
-      <display value="Jamila J XXX_Kwee"/>
-   </subject>
-   <context>
-      <reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000"/>
-      <display value="prenatale controle T-193D Vrouw2"/>
-   </context>
-   <effectivePeriod>
-      <start value="2019-06-01"/>
-      <end value="${DATE, T, D, -198}"/>
-   </effectivePeriod>
-   <valueCodeableConcept>
-      <coding>
-         <system value="http://snomed.info/sct"/>
-         <code value="8517006"/>
-         <display value="rookte vroeger"/>
-      </coding>
-   </valueCodeableConcept>
-   <component>
-      <code>
-         <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="53661000146106" />
-            <display value="type tabak gebruikt (waarneembare entiteit)" />
-         </coding>
-      </code>
-      <valueCodeableConcept>
-         <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="722499006" />
-            <display value="gebruiker van elektronische sigaret" />
-         </coding>
-      </valueCodeableConcept>
-   </component>
-   <comment value="gestopt op advies verloskundige"/>
+	<id value="a4907ae9-2291-11ec-8669-020000000000" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-observation" />
+		<profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TobaccoUse" />
+	</meta>
+	<identifier>
+		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
+		<value value="97ea1e41-a6d9-11ed-2072-020000000000" />
+	</identifier>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="365980008" />
+			<display value="bevinding betreffende tabakgebruik en blootstelling aan tabaksrook (bevinding)" />
+		</coding>
+	</code>
+	<subject>
+		<reference value="Patient/JAMILAJXXX-KWEE" />
+		<display value="Jamila J XXX_Kwee" />
+	</subject>
+	<context>
+		<reference value="Encounter/a4907ad7-2291-11ec-8669-020000000000" />
+		<display value="prenatale controle T-193D Vrouw2" />
+	</context>
+	<effectivePeriod>
+		<start value="2019-06-01" />
+		<end value="${DATE, T, D, -198}" />
+	</effectivePeriod>
+	<valueCodeableConcept>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="8517006" />
+			<display value="rookte vroeger (bevinding)" />
+		</coding>
+	</valueCodeableConcept>
+	<component>
+		<code>
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="53661000146106" />
+				<display value="type tabak gebruikt (waarneembare entiteit)" />
+			</coding>
+		</code>
+		<valueCodeableConcept>
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="722499006" />
+				<display value="gebruiker van elektronische sigaret" />
+			</coding>
+		</valueCodeableConcept>
+	</component>
+	<comment value="gestopt op advies verloskundige" />
 </Observation>

--- a/src/Geboortezorg-3-2/Cert/_reference/Vrouw3-GeenData/medmij-gbz-nl-core-patient-JULIAJXXX-LAARHOVEN.xml
+++ b/src/Geboortezorg-3-2/Cert/_reference/Vrouw3-GeenData/medmij-gbz-nl-core-patient-JULIAJXXX-LAARHOVEN.xml
@@ -1,78 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-   <id value="JULIAJXXX-LAARHOVEN"/>
-   <meta>
-      <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient"/>
-   </meta>
-   <text>
-      <status value="generated"/>
-      <div xmlns="http://www.w3.org/1999/xhtml">
-         <div>Julia J XXX_Laarhoven, Vrouw, 22 oktober 1985</div>
-         <div>Knolweg 1002, 9999ZZ STITSWERD ()</div>
-      </div>
-   </text>
-   <identifier>
-      <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
-      <value>
-         <extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
-            <valueCode value="masked"/>
-         </extension>
-      </value>
-   </identifier>
-   <name>
-      <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-         <valueCode value="NL1"/>
-      </extension>
-      <text value="Julia XXX_Laarhoven"/>
-      <family value="XXX_Laarhoven">
-         <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
-            <valueString value="XXX_Laarhoven"/>
-         </extension>
-      </family>
-      <given value="Julia">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="BR"/>
-         </extension>
-      </given>
-      <given value="J">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
-            <valueCode value="IN"/>
-         </extension>
-      </given>
-   </name>
-   <gender value="female">
-      <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-         <valueCodeableConcept>
-            <coding>
-               <system value="http://hl7.org/fhir/v3/AdministrativeGender"/>
-               <code value="F"/>
-               <display value="Vrouw"/>
-            </coding>
-         </valueCodeableConcept>
-      </extension>
-   </gender>
-   <birthDate value="1985-10-22"/>
-   <address>
-      <line value="Knolweg 1002">
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
-            <valueString value="Knolweg"/>
-         </extension>
-         <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
-            <valueString value="1002"/>
-         </extension>
-      </line>
-      <city value="STITSWERD"/>
-      <postalCode value="9999ZZ"/>
-      <country value="NLD">
-         <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
-            <valueCodeableConcept>
-               <coding>
-                  <system value="urn:oid:2.16.840.1.113883.2.4.4.16.34"/>
-                  <code value="6030"/>
-                  <display value="Nederland"/>
-               </coding>
-            </valueCodeableConcept>
-         </extension>
-      </country>
-   </address>
+	<id value="JULIAJXXX-LAARHOVEN" />
+	<meta>
+		<profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div>
+			<div>Julia J XXX_Laarhoven, Vrouw, 22 oktober 1985</div>
+			<div>Knolweg 1002, 9999ZZ STITSWERD ()</div>
+		</div>
+	</text>
+	<identifier>
+		<system value="http://fhir.nl/fhir/NamingSystem/bsn" />
+		<value>
+			<extension url="http://hl7.org/fhir/StructureDefinition/data-absent-reason">
+				<valueCode value="masked" />
+			</extension>
+		</value>
+	</identifier>
+	<name>
+		<extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
+			<valueCode value="NL1" />
+		</extension>
+		<text value="Julia XXX_Laarhoven" />
+		<family value="XXX_Laarhoven">
+			<extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+				<valueString value="XXX_Laarhoven" />
+			</extension>
+		</family>
+		<given value="Julia">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="BR" />
+			</extension>
+		</given>
+		<given value="J">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+				<valueCode value="IN" />
+			</extension>
+		</given>
+	</name>
+	<gender value="female">
+		<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+			<valueCodeableConcept>
+				<coding>
+					<system value="http://hl7.org/fhir/v3/AdministrativeGender" />
+					<code value="F" />
+					<display value="Vrouw" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</gender>
+	<birthDate value="1985-10-22" />
+	<address>
+		<line value="Knolweg 1002">
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+				<valueString value="Knolweg" />
+			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+				<valueString value="1002" />
+			</extension>
+		</line>
+		<city value="STITSWERD" />
+		<postalCode value="9999ZZ" />
+		<country value="NLD">
+			<extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+				<valueCodeableConcept>
+					<coding>
+						<system value="urn:oid:2.16.840.1.113883.2.4.4.16.34" />
+						<code value="6030" />
+						<display value="Nederland" />
+					</coding>
+				</valueCodeableConcept>
+			</extension>
+		</country>
+	</address>
 </Patient>

--- a/src/eOverdracht-4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Cert/Sending-XIS/Scenario1-1b-phase2-handoff.xml
@@ -9,10 +9,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-cert-1-1b-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-cert-1_1b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-cert-1_1b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Cert/_reference/resources/resources-generic/nl-core-patient-eov-cert-1_1b-01.xml
+++ b/src/eOverdracht-4-0/Cert/_reference/resources/resources-generic/nl-core-patient-eov-cert-1_1b-01.xml
@@ -11,7 +11,7 @@
   <active value="true" />
   <name>
     <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
-      <valueCode value="NL4" />
+      <valueCode value="NL1" />
     </extension>
     <text value="Maria XXX_Molog" />
     <family value="XXX_Molog">

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1-phase1-negotiation.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.1, test 1/2 for eOverdracht sending systems. This test focuses on the negotiation phase ('aanmeldfase') where a receiving xis agrees to transfer the patient at the proposed date and time. After completion of this test, the test for the transfer phase ('overdrachtfase') can be run."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-1-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_1-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_1-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1-phase2-handoff.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.1, test 2/2 for eOverdracht sending systems. This test focuses on the handoff phase ('overdrachtfase'). In a normal scenario, the test for the negotiation phase ('aanmeldfase') has been completed before running this test, although it may be performed in isolation."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-1-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_1-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_1-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-10b-phase2-handoff.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.10b for eOverdracht sending systems. This test asumes that the transfer starts directly in the handoff phase ('overdrachtfase') and that there is no negotiation phase."/>
     
     <nts:authToken patientResourceId="XXX-Hondius"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_10b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_10b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-11b-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="XXX-Hondius"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_11b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_11b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1b-phase1-negotiation.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.1b, test 1/2 for eOverdracht sending systems. This test focuses on the negotiation phase ('aanmeldfase') where a receiving xis agrees to transfer the patient at the proposed date and time. After completion of this test, the test for the transfer phase ('overdrachtfase') can be run."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-1b-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_1b-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_1b-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-1b-phase2-handoff.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.1b, test 2/2 for eOverdracht sending systems. This test focuses on the handoff phase ('overdrachtfase'). In a normal scenario, the test for the negotiation phase ('aanmeldfase') has been completed before running this test, although it may be performed in isolation."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-1b-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->    
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_1b-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_1b-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-2b-phase1-negotiation.xml
@@ -11,10 +11,15 @@
     <nts:includeDateT value="yes"/>
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-2b-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_2b-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_2b-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-2b-phase2-handoff.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.2b, test 2/2 for eOverdracht sending systems. This test focuses on the handoff phase ('overdrachtfase'). In a normal scenario, the test for the negotiation phase ('aanmeldfase') has been completed before running this test, although it may be performed in isolation."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-2b-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_2b-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_2b-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-3b-phase1-negotiation.xml
@@ -10,11 +10,16 @@
     
     <nts:includeDateT value="yes"/>
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-3b-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_3b-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_3b-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-3b-phase2-handoff.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.3b for eOverdracht sending systems. This test asumes that the transfer starts directly in the handoff phase ('overdrachtfase') and that there is no negotiation phase. Note that the _is_ a test for the negotiation phase with the same test data, but that doesn't result in the transfer of the patient."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-3b-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_3b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_3b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-4b-phase1-negotiation.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-4b-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_4b-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_4b-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-4b-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-4b-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_4b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_4b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-5-phase1-negotiation.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-5-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_5-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_5-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-5-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-5-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_5-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_5-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-6-phase1-negotiation.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-6-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_6-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_6-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-6-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-6-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_6-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_6-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-7-phase1-negotiation.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-7-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_7-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_7-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-7-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-7-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_7-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_7-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-8-phase1-negotiation.xml
@@ -9,11 +9,16 @@
     <description value="Scenario 1.8, test 1/2 for eOverdracht sending systems. This test focuses on the negotiation phase ('aanmeldfase') where a receiving xis agrees to transfer the patient at the proposed date and time. After completion of this test, the test for the transfer phase ('overdrachtfase') can be run."/>
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-8-01"/>
-    
+
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_8-REQUESTED.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_8-REQUESTED.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'requested'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-8-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="nl-core-patient-eov-test-1-8-01"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_8-IN-PROGRESS2.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_8-IN-PROGRESS2.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>

--- a/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff.xml
+++ b/src/eOverdracht-4-0/Test/Sending-XIS/Scenario1-9b-phase2-handoff.xml
@@ -10,10 +10,15 @@
     
     <nts:authToken patientResourceId="XXX-Hondius"/>
     
+    <!--
+        EOVDR-444/KT-384: Declare a (unused) fixture as a workaround for a Touchstone bug.
+        The line below should be put back in the setup once KT-384 has been resolved.
+    -->
+    <nts:fixture
+        id="initial-task-fixture"
+        href="resources/resources-specific/eOverdracht-Task-eov-test-1_9b-IN-PROGRESS.xml"/>
+
     <setup nts:in-targets="Nictiz-only">
-        <nts:fixture
-            id="initial-task-fixture"
-            href="resources/resources-specific/eOverdracht-Task-eov-test-1_9b-IN-PROGRESS.xml"/>
         <nts:include value="setup.general.initializeTask"
             task-fixture-id="initial-task-fixture"
             description="At the sending XIS, a new Task is created in status 'in-progress'."/>


### PR DESCRIPTION
Started last month (july) with this patchrelease. Merges are from the last update EOVDR-444, so it is up to date.