### PR TITLE
Nictiz 32049

### DIFF
--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-1-json.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-1-json.xml
@@ -3278,17 +3278,6 @@
       <action>
          <assert>
             <label value="1-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="1-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').status = 'final''-->
@@ -3299,7 +3288,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-5"/>
+            <label value="1-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -3310,7 +3299,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-6"/>
+            <label value="1-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3321,7 +3310,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-7"/>
+            <label value="1-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3332,7 +3321,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-8"/>
+            <label value="1-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -3390,17 +3379,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').status = 'final''-->
@@ -3411,7 +3389,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -3422,7 +3400,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3433,7 +3411,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3444,7 +3422,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-1-xml.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-1-xml.xml
@@ -3278,17 +3278,6 @@
       <action>
          <assert>
             <label value="1-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="1-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').status = 'final''-->
@@ -3299,7 +3288,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-5"/>
+            <label value="1-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -3310,7 +3299,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-6"/>
+            <label value="1-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3321,7 +3310,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-7"/>
+            <label value="1-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3332,7 +3321,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-8"/>
+            <label value="1-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47afc6-2063-11ec-1749-020000000000-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -3390,17 +3379,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').status = 'final''-->
@@ -3411,7 +3389,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -3422,7 +3400,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3433,7 +3411,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3444,7 +3422,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${0d47gec7-2063-11ec-1751-020000000000-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-2-json.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-2-json.xml
@@ -7425,17 +7425,6 @@
       <action>
          <assert>
             <label value="33-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="33-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').status = 'final''-->
@@ -7446,7 +7435,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-5"/>
+            <label value="33-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -7457,7 +7446,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-6"/>
+            <label value="33-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -7468,7 +7457,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-7"/>
+            <label value="33-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').context.where((reference or identifier) and display).exists()'-->
@@ -7479,7 +7468,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-8"/>
+            <label value="33-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -7537,17 +7526,6 @@
       <action>
          <assert>
             <label value="34-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="34-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').status = 'final''-->
@@ -7558,7 +7536,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-5"/>
+            <label value="34-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -7569,7 +7547,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-6"/>
+            <label value="34-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -7580,7 +7558,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-7"/>
+            <label value="34-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').context.where((reference or identifier) and display).exists()'-->
@@ -7591,7 +7569,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-8"/>
+            <label value="34-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-2-xml.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-2-2-xml.xml
@@ -7425,17 +7425,6 @@
       <action>
          <assert>
             <label value="33-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="33-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').status = 'final''-->
@@ -7446,7 +7435,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-5"/>
+            <label value="33-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -7457,7 +7446,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-6"/>
+            <label value="33-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -7468,7 +7457,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-7"/>
+            <label value="33-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').context.where((reference or identifier) and display).exists()'-->
@@ -7479,7 +7468,7 @@
       </action>
       <action>
          <assert>
-            <label value="33-8"/>
+            <label value="33-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${98854706-998c-4fcb-9df3-7720e151fb27-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -7537,17 +7526,6 @@
       <action>
          <assert>
             <label value="34-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="34-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').status = 'final''-->
@@ -7558,7 +7536,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-5"/>
+            <label value="34-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -7569,7 +7547,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-6"/>
+            <label value="34-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -7580,7 +7558,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-7"/>
+            <label value="34-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').context.where((reference or identifier) and display).exists()'-->
@@ -7591,7 +7569,7 @@
       </action>
       <action>
          <assert>
-            <label value="34-8"/>
+            <label value="34-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${da1db3bd-6722-4736-adc1-f96a0722a4f5-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-1-json.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-1-json.xml
@@ -4509,17 +4509,6 @@
       <action>
          <assert>
             <label value="3-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="3-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').status = 'final''-->
@@ -4530,7 +4519,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-5"/>
+            <label value="3-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').code.coding.where(system = 'http://loinc.org' and code = '11977-6' and display).exists()'-->
@@ -4541,7 +4530,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-6"/>
+            <label value="3-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4552,7 +4541,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-7"/>
+            <label value="3-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4563,7 +4552,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-8"/>
+            <label value="3-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -4621,17 +4610,6 @@
       <action>
          <assert>
             <label value="4-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="4-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').status = 'final''-->
@@ -4642,7 +4620,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-5"/>
+            <label value="4-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').code.coding.where(system = 'http://loinc.org' and code = '11996-6' and display).exists()'-->
@@ -4653,7 +4631,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-6"/>
+            <label value="4-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4664,7 +4642,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-7"/>
+            <label value="4-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4675,7 +4653,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-8"/>
+            <label value="4-7"/>
             <description value="Contains .valueQuantity with .value '2' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').value.ofType(Quantity).where(value = 2 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-1-xml.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-1-xml.xml
@@ -4509,17 +4509,6 @@
       <action>
          <assert>
             <label value="3-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="3-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').status = 'final''-->
@@ -4530,7 +4519,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-5"/>
+            <label value="3-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').code.coding.where(system = 'http://loinc.org' and code = '11977-6' and display).exists()'-->
@@ -4541,7 +4530,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-6"/>
+            <label value="3-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4552,7 +4541,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-7"/>
+            <label value="3-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4563,7 +4552,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-8"/>
+            <label value="3-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${fc075697-750b-4d3d-8376-c93f58d8bdfd-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -4621,17 +4610,6 @@
       <action>
          <assert>
             <label value="4-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="4-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').status = 'final''-->
@@ -4642,7 +4620,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-5"/>
+            <label value="4-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').code.coding.where(system = 'http://loinc.org' and code = '11996-6' and display).exists()'-->
@@ -4653,7 +4631,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-6"/>
+            <label value="4-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4664,7 +4642,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-7"/>
+            <label value="4-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4675,7 +4653,7 @@
       </action>
       <action>
          <assert>
-            <label value="4-8"/>
+            <label value="4-7"/>
             <description value="Contains .valueQuantity with .value '2' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${a91713db-aded-43ce-b54b-9a85c3eb9aa7-id}').value.ofType(Quantity).where(value = 2 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-2-json.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-2-json.xml
@@ -3931,17 +3931,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').status = 'final''-->
@@ -3952,7 +3941,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -3963,7 +3952,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3974,7 +3963,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3985,7 +3974,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '0' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').value.ofType(Quantity).where(value = 0 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -4043,17 +4032,6 @@
       <action>
          <assert>
             <label value="3-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="3-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').status = 'final''-->
@@ -4064,7 +4042,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-5"/>
+            <label value="3-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -4075,7 +4053,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-6"/>
+            <label value="3-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4086,7 +4064,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-7"/>
+            <label value="3-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4097,7 +4075,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-8"/>
+            <label value="3-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-2-xml.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-2-xml.xml
@@ -3931,17 +3931,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').status = 'final''-->
@@ -3952,7 +3941,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '364325004' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11977-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '364325004' and display)).exists()'-->
@@ -3963,7 +3952,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -3974,7 +3963,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').context.where((reference or identifier) and display).exists()'-->
@@ -3985,7 +3974,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '0' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${3972fab7-e276-40d9-b7ac-eb9a7490700a-id}').value.ofType(Quantity).where(value = 0 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -4043,17 +4032,6 @@
       <action>
          <assert>
             <label value="3-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="3-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').status = 'final''-->
@@ -4064,7 +4042,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-5"/>
+            <label value="3-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display and .coding with .system 'http://snomed.info/sct' and .code '161732006' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').code.where(coding.where(system = 'http://loinc.org' and code = '11996-6' and display) and coding.where(system = 'http://snomed.info/sct' and code = '161732006' and display)).exists()'-->
@@ -4075,7 +4053,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-6"/>
+            <label value="3-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -4086,7 +4064,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-7"/>
+            <label value="3-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').context.where((reference or identifier) and display).exists()'-->
@@ -4097,7 +4075,7 @@
       </action>
       <action>
          <assert>
-            <label value="3-8"/>
+            <label value="3-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${2eb59392-d8d6-400e-a277-587b7c976f62-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-3-json.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-3-json.xml
@@ -2628,17 +2628,6 @@
       <action>
          <assert>
             <label value="1-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="1-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').status = 'final''-->
@@ -2649,7 +2638,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-5"/>
+            <label value="1-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').code.coding.where(system = 'http://loinc.org' and code = '11977-6' and display).exists()'-->
@@ -2660,7 +2649,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-6"/>
+            <label value="1-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -2671,7 +2660,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-7"/>
+            <label value="1-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').context.where((reference or identifier) and display).exists()'-->
@@ -2682,7 +2671,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-8"/>
+            <label value="1-7"/>
             <description value="Contains .valueQuantity with .value '0' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').value.ofType(Quantity).where(value = 0 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -2740,17 +2729,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').status = 'final''-->
@@ -2761,7 +2739,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').code.coding.where(system = 'http://loinc.org' and code = '11996-6' and display).exists()'-->
@@ -2772,7 +2750,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -2783,7 +2761,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').context.where((reference or identifier) and display).exists()'-->
@@ -2794,7 +2772,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-3-xml.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/XIS-Server-CheckContent/gbz-fhir3-0-2-izk-xis-4-3-xml.xml
@@ -2628,17 +2628,6 @@
       <action>
          <assert>
             <label value="1-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="1-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').status = 'final''-->
@@ -2649,7 +2638,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-5"/>
+            <label value="1-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11977-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').code.coding.where(system = 'http://loinc.org' and code = '11977-6' and display).exists()'-->
@@ -2660,7 +2649,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-6"/>
+            <label value="1-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -2671,7 +2660,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-7"/>
+            <label value="1-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').context.where((reference or identifier) and display).exists()'-->
@@ -2682,7 +2671,7 @@
       </action>
       <action>
          <assert>
-            <label value="1-8"/>
+            <label value="1-7"/>
             <description value="Contains .valueQuantity with .value '0' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${9680b939-560e-472e-9ad5-1ee9b62873ea-id}').value.ofType(Quantity).where(value = 0 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->
@@ -2740,17 +2729,6 @@
       <action>
          <assert>
             <label value="2-3"/>
-            <description value="Contains .identifier with .system and .value"/>
-            <direction value="response"/>
-            <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').identifier.where(system and value).exists()'-->
-            <expression value="Bundle.entry.resource.where($this is Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').identifier.where(system and value).exists()"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <label value="2-4"/>
             <description value="Contains .status 'final'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').status = 'final''-->
@@ -2761,7 +2739,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-5"/>
+            <label value="2-4"/>
             <description value="Contains .code with .coding with .system 'http://loinc.org' and .code '11996-6' and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').code.coding.where(system = 'http://loinc.org' and code = '11996-6' and display).exists()'-->
@@ -2772,7 +2750,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-6"/>
+            <label value="2-5"/>
             <description value="Contains .subject with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').subject.where((reference or identifier) and display).exists()'-->
@@ -2783,7 +2761,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-7"/>
+            <label value="2-6"/>
             <description value="Contains .context with either .reference or .identifier and .display"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').context.where((reference or identifier) and display).exists()'-->
@@ -2794,7 +2772,7 @@
       </action>
       <action>
          <assert>
-            <label value="2-8"/>
+            <label value="2-7"/>
             <description value="Contains .valueQuantity with .value '1' and .unit and .system 'http://unitsofmeasure.org' and .code '1'"/>
             <direction value="response"/>
             <!--FHIRPath expressions with .ofType(...) are poorly supported at the moment, so it was rewritten. Original expression: 'Bundle.entry.resource.ofType(Observation).where(id = '${7eea12fa-8dbf-4957-9500-931888b76138-id}').value.ofType(Quantity).where(value = 1 and unit and system = 'http://unitsofmeasure.org' and code = '1').exists()'-->

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-76d22171-280c-4386-9e53-08ea8c8cd13b.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-76d22171-280c-4386-9e53-08ea8c8cd13b.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Id: 7e7b683b-a6d9-11ed-6610-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 1 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b683b-a6d9-11ed-6610-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-852770ba-c05c-4373-a814-bed3fec708a3.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-852770ba-c05c-4373-a814-bed3fec708a3.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Id: 7e992d6b-a6e2-13ec-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 1 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e992d6b-a6e2-13ec-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d67gec5-2663-11ec-1741-020000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d67gec5-2663-11ec-1741-020000000000.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Id: 7e7b684b-a6d9-11ed-6610-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 2 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b684b-a6d9-11ed-6610-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-1963-12ec-1142-030000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-1963-12ec-1142-030000000000.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Id: 7e991d6b-a6e2-13ec-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Leonie XXX_Osse. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 2 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e991d6b-a6e2-13ec-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-1063-12ec-1851-090000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-1063-12ec-1851-090000000000.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Merthe XXX_Kooijman. Id: 7e7b663b-a4d9-14ed-6510-070000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Merthe XXX_Kooijman. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 1 Merthe Kooijman"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b663b-a4d9-14ed-6510-070000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Parity364325004-0d47a4c6-2033-21eb-1759-090000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Parity364325004-0d47a4c6-2033-21eb-1759-090000000000.xml
@@ -7,7 +7,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Merthe XXX_Kooijman. Id: 7e991t6b-a4e5-16ed-1034-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Merthe XXX_Kooijman. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -33,10 +33,6 @@
       <display value="Zwangerschap 1 Merthe Kooijman"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e991t6b-a4e5-16ed-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-2063-11ec-1751-020000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-2063-11ec-1751-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Kim K XXX_Zhanganak. Id: 7e7b683b-a6d9-11ed-6610-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Kim K XXX_Zhanganak. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Kim Zhanganak"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b683b-a6d9-11ed-6610-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1749-020000000000.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1749-020000000000.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Kim K XXX_Zhanganak. Id: 7e992d6b-a6d9-11ed-1094-020000000000 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Kim K XXX_Zhanganak. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Kim Zhanganak"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e992d6b-a6d9-11ed-1094-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-2-98854706-998c-4fcb-9df3-7720e151fb27.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-2-98854706-998c-4fcb-9df3-7720e151fb27.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Linda K XXX_Smit. Id: 7181bc2c-df1d-46c5-bbeb-66ff7ed1aa2b (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Linda K XXX_Smit. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Linda Hollanders"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7181bc2c-df1d-46c5-bbeb-66ff7ed1aa2b"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-2-da1db3bd-6722-4736-adc1-f96a0722a4f5.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-2-da1db3bd-6722-4736-adc1-f96a0722a4f5.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Linda XXX_Hollanders. Id: 74242875-562a-434c-ae69-3839da50f73a (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Linda XXX_Hollanders. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Linda Hollanders"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="74242875-562a-434c-ae69-3839da50f73a"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-a91713db-aded-43ce-b54b-9a85c3eb9aa7.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-a91713db-aded-43ce-b54b-9a85c3eb9aa7.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Vrouw: Ostendorf Maaike. Id: a91713db-aded-43ce-b54b-9a85c3eb9aa7 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Vrouw: Ostendorf Maaike. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap: Ostendorf Maaike"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="a91713db-aded-43ce-b54b-9a85c3eb9aa7"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Parity-11977-6-fc075697-750b-4d3d-8376-c93f58d8bdfd.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Parity-11977-6-fc075697-750b-4d3d-8376-c93f58d8bdfd.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Vrouw: Ostendorf Maaike. Id: fc075697-750b-4d3d-8376-c93f58d8bdfd (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Vrouw: Ostendorf Maaike. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap: Ostendorf Maaike"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="fc075697-750b-4d3d-8376-c93f58d8bdfd"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Gravidity-2eb59392-d8d6-400e-a277-587b7c976f62.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Gravidity-2eb59392-d8d6-400e-a277-587b7c976f62.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Fiona XXX_Swart. Id: 2eb59392-d8d6-400e-a277-587b7c976f62 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Fiona XXX_Swart. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Vrouw2"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="2eb59392-d8d6-400e-a277-587b7c976f62"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Parity-3972fab7-e276-40d9-b7ac-eb9a7490700a.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Parity-3972fab7-e276-40d9-b7ac-eb9a7490700a.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Fiona XXX_Swart. Id: 3972fab7-e276-40d9-b7ac-eb9a7490700a (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Fiona XXX_Swart. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap 1 Vrouw2"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="3972fab7-e276-40d9-b7ac-eb9a7490700a"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-7eea12fa-8dbf-4957-9500-931888b76138.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-7eea12fa-8dbf-4957-9500-931888b76138.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Vrouw: Yassien-Mohamed Micha. Id: 7eea12fa-8dbf-4957-9500-931888b76138 (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Vrouw: Yassien-Mohamed Micha. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap: Yassien-Mohamed Micha"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7eea12fa-8dbf-4957-9500-931888b76138"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Parity-11977-6-9680b939-560e-472e-9ad5-1ee9b62873ea.xml
+++ b/output/STU3/Geboortezorg-2-0-0-alpha-1/MedMij/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Parity-11977-6-9680b939-560e-472e-9ad5-1ee9b62873ea.xml
@@ -8,7 +8,7 @@
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <table>
-        <caption>Observatie/bepaling. Subject: Vrouw: Yassien-Mohamed Micha. Id: 9680b939-560e-472e-9ad5-1ee9b62873ea (urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6), Status: definitief</caption>
+        <caption>Observatie/bepaling. Subject: Vrouw: Yassien-Mohamed Micha. Status: definitief</caption>
         <tbody>
           <tr>
             <th>Context</th>
@@ -34,10 +34,6 @@
       <display value="Zwangerschap: Yassien-Mohamed Micha"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="9680b939-560e-472e-9ad5-1ee9b62873ea"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-76d22171-280c-4386-9e53-08ea8c8cd13b.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-76d22171-280c-4386-9e53-08ea8c8cd13b.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 1 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b683b-a6d9-11ed-6610-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-852770ba-c05c-4373-a814-bed3fec708a3.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-852770ba-c05c-4373-a814-bed3fec708a3.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 1 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e992d6b-a6e2-13ec-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d67gec5-2663-11ec-1741-020000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d67gec5-2663-11ec-1741-020000000000.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 2 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b684b-a6d9-11ed-6610-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-1963-12ec-1142-030000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-1963-12ec-1142-030000000000.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 2 Leonie Osse"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e991d6b-a6e2-13ec-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-1063-12ec-1851-090000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-1063-12ec-1851-090000000000.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 1 Merthe Kooijman"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e7b663b-a4d9-14ed-6510-070000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Parity364325004-0d47a4c6-2033-21eb-1759-090000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Echo-Casus3/medmij-gbz-zib-Pregnancy-Parity364325004-0d47a4c6-2033-21eb-1759-090000000000.xml
@@ -9,10 +9,6 @@
       <display value="Zwangerschap 1 Merthe Kooijman"/>
     </valueReference>
   </extension>
-  <identifier>
-    <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-    <value value="7e991t6b-a4e5-16ed-1034-020000000000"/>
-  </identifier>
   <status value="final"/>
   <code>
     <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-2063-11ec-1751-020000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Gravidity161732006-0d47gec7-2063-11ec-1751-020000000000.xml
@@ -10,10 +10,6 @@
 			<display value="Zwangerschap 1 Kim Zhanganak" />
 		</valueReference>
 	</extension>
-	<identifier>
-		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-		<value value="7e7b683b-a6d9-11ed-6610-020000000000" />
-	</identifier>
 	<status value="final" />
 	<code>
 		<coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1749-020000000000.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus1/medmij-gbz-zib-Pregnancy-Parity364325004-0d47afc6-2063-11ec-1749-020000000000.xml
@@ -10,10 +10,6 @@
 			<display value="Zwangerschap 1 Kim Zhanganak" />
 		</valueReference>
 	</extension>
-	<identifier>
-		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-		<value value="7e992d6b-a6d9-11ed-1094-020000000000" />
-	</identifier>
 	<status value="final" />
 	<code>
 		<coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-2-98854706-998c-4fcb-9df3-7720e151fb27.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Gravidity161732006-2-98854706-998c-4fcb-9df3-7720e151fb27.xml
@@ -10,10 +10,6 @@
 		<display value="Zwangerschap 1 Linda Hollanders" />
 		</valueReference>
 	</extension>
-	<identifier>
-		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-		<value value="7181bc2c-df1d-46c5-bbeb-66ff7ed1aa2b" />
-	</identifier>
 	<status value="final" />
 	<code>
 		<coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-2-da1db3bd-6722-4736-adc1-f96a0722a4f5.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Kraam-Casus2/medmij-gbz-zib-Pregnancy-Parity364325004-2-da1db3bd-6722-4736-adc1-f96a0722a4f5.xml
@@ -10,10 +10,6 @@
 		<display value="Zwangerschap 1 Linda Hollanders" />
 		</valueReference>
 	</extension>
-	<identifier>
-		<system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6" />
-		<value value="74242875-562a-434c-ae69-3839da50f73a" />
-	</identifier>
 	<status value="final" />
 	<code>
 		<coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-a91713db-aded-43ce-b54b-9a85c3eb9aa7.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-a91713db-aded-43ce-b54b-9a85c3eb9aa7.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap: Ostendorf Maaike"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="a91713db-aded-43ce-b54b-9a85c3eb9aa7"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Parity-11977-6-fc075697-750b-4d3d-8376-c93f58d8bdfd.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus1/medmij-gbz-zib-Pregnancy-Parity-11977-6-fc075697-750b-4d3d-8376-c93f58d8bdfd.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap: Ostendorf Maaike"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="fc075697-750b-4d3d-8376-c93f58d8bdfd"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Gravidity-2eb59392-d8d6-400e-a277-587b7c976f62.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Gravidity-2eb59392-d8d6-400e-a277-587b7c976f62.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap 1 Vrouw2"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="2eb59392-d8d6-400e-a277-587b7c976f62"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Parity-3972fab7-e276-40d9-b7ac-eb9a7490700a.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus2/zib-Pregnancy-Parity-3972fab7-e276-40d9-b7ac-eb9a7490700a.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap 1 Vrouw2"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="3972fab7-e276-40d9-b7ac-eb9a7490700a"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-7eea12fa-8dbf-4957-9500-931888b76138.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Gravidity-11996-6-7eea12fa-8dbf-4957-9500-931888b76138.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap: Yassien-Mohamed Micha"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="7eea12fa-8dbf-4957-9500-931888b76138"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>

--- a/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Parity-11977-6-9680b939-560e-472e-9ad5-1ee9b62873ea.xml
+++ b/src/Geboortezorg-2-0/Cert/_reference/Verloskunde-Casus3/medmij-gbz-zib-Pregnancy-Parity-11977-6-9680b939-560e-472e-9ad5-1ee9b62873ea.xml
@@ -11,10 +11,6 @@
          <display value="Zwangerschap: Yassien-Mohamed Micha"/>
       </valueReference>
    </extension>
-   <identifier>
-      <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.7.6"/>
-      <value value="9680b939-560e-472e-9ad5-1ee9b62873ea"/>
-   </identifier>
    <status value="final"/>
    <code>
       <coding>


### PR DESCRIPTION
(NICTIZ-32049) remove identifier fields from Parity and Gravidity Observations in all qualification materials
and
(NICTIZ-32049) Build output for Geboortezorg-2-0 Cert materials
