### PR TITLE
MM-5669 Operation read vervangen door search

### DIFF
--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-01-X-respiration.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-01-X-respiration.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -282,10 +282,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-02-X-bodyheight.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-02-X-bodyheight.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -272,10 +272,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-03-X-bodytemp.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-03-X-bodytemp.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -282,10 +282,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-04-X-saturation.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-04-X-saturation.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -262,10 +262,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-05-X-pulserates.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-05-X-pulserates.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -262,10 +262,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-06-X-bloodpressure.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-06-X-bloodpressure.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -197,10 +197,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -282,10 +282,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-07-X-bodyweight.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-07-X-bodyweight.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -262,10 +262,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-08-X-bloodglucose.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-08-X-bloodglucose.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -282,10 +282,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-09-X-heartrate.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-09-X-heartrate.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -187,10 +187,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -272,10 +272,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-10-X-multiple.xml
+++ b/output/STU3/SelfMeasurements-2-0/MedMij/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-10-X-multiple.xml
@@ -47,10 +47,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -112,10 +112,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>
@@ -177,10 +177,10 @@
          <operation>
             <type>
                <system value="http://hl7.org/fhir/restful-interaction"/>
-               <code value="read"/>
+               <code value="search"/>
             </type>
             <resource value="Observation"/>
-            <description value="Test PHR client to read Observation resource."/>
+            <description value="Test PHR client to retrieve Observation resources."/>
             <destination value="1"/>
             <encodeRequestUrl value="true"/>
             <origin value="1"/>

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-01-X-respiration.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-01-X-respiration.xml
@@ -13,7 +13,7 @@
     <test id="scenario1-1-retrieve-all-respiration">
         <name value="Scenario 1.1"/>
         <description value="Retrieve all respiration Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|422834003"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario1-2-retrieve-all-respiration">
         <name value="Scenario 1.2"/>
         <description value="Retrieve latest respiration Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|422834003"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario1-3-retrieve-all-respirations">
         <name value="Scenario 1.3"/>
         <description value="Retrieve period respiration Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|422834003&amp;date=ge${DATE, T, D,-14}&amp;date=le${DATE, T, D,-1}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -73,7 +73,7 @@
     <test id="scenario1-4-retrieve-all-respirations">
         <name value="Scenario 1.4"/>
         <description value="Retrieve period respiration Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|422834003&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-02-X-bodyheight.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-02-X-bodyheight.xml
@@ -13,7 +13,7 @@
     <test id="scenario2-1-retrieve-all-bodyheight">
         <name value="Scenario 2.1"/>
         <description value="Retrieve all bodyheight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8302-2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario2-2-retrieve-all-bodyheight">
         <name value="Scenario 2.2"/>
         <description value="Retrieve latest bodyheight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8302-2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario2-3-retrieve-all-bodyheights">
         <name value="Scenario 2.3"/>
         <description value="Retrieve period bodyheight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8302-2&amp;date=ge${DATE, T, D,-800}&amp;date=le${DATE, T, D,-350}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -66,7 +66,7 @@
     <test id="scenario2-4-retrieve-all-bodyheights">
         <name value="Scenario 2.4"/>
         <description value="Retrieve period bodyheight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8302-2&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-03-X-bodytemp.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-03-X-bodytemp.xml
@@ -13,7 +13,7 @@
     <test id="scenario3-1-retrieve-all-bodyTemperature">
         <name value="Scenario 3.1"/>
         <description value="Retrieve all bodyTemperature Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8310-5"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario3-2-retrieve-all-bodyTemperature">
         <name value="Scenario 3.2"/>
         <description value="Retrieve latest bodyTemperature Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8310-5"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario3-3-retrieve-all-bodyTemperatures">
         <name value="Scenario 3.3"/>
         <description value="Retrieve period bodyTemperature Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8310-5&amp;date=ge${DATE, T, D,-50}&amp;date=le${DATE, T, D,-20}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -73,7 +73,7 @@
     <test id="scenario3-4-retrieve-all-bodyTemperatures">
         <name value="Scenario 3.4"/>
         <description value="Retrieve period bodyTemperature Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8310-5&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-51}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-04-X-saturation.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-04-X-saturation.xml
@@ -13,7 +13,7 @@
     <test id="scenario4-1-retrieve-all-saturation">
         <name value="Scenario 4.1"/>
         <description value="Retrieve all saturation Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|59408-5"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario4-2-retrieve-all-saturations">
         <name value="Scenario 4.2"/>
         <description value="Retrieve latest saturation Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|59408-5"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario4-3-retrieve-all-saturations">
         <name value="Scenario 4.3"/>
         <description value="Retrieve period saturation Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|59408-5&amp;date=ge${DATE, T, D,-365}&amp;date=le${DATE, T, D,-20}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -59,7 +59,7 @@
     <test id="scenario4-4-retrieve-all-saturations">
         <name value="Scenario 4.4"/>
         <description value="Retrieve period saturation Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|59408-5&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-05-X-pulserates.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-05-X-pulserates.xml
@@ -13,7 +13,7 @@
     <test id="scenario5-5-retrieve-all-pulserates">
         <name value="Scenario 5.1"/>
         <description value="Retrieve all PulseRate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8893-0"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario5-2-retrieve-all-pulserates">
         <name value="Scenario 5.2"/>
         <description value="Retrieve latest PulseRate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8893-0"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario5-3-retrieve-all-pulserates">
         <name value="Scenario 5.3"/>
         <description value="Retrieve period PulseRate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8893-0&amp;date=ge${DATE, T, D,-800}&amp;date=le${DATE, T, D,-365}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -59,7 +59,7 @@
     <test id="scenario5-4-retrieve-all-pulserates">
         <name value="Scenario 5.4"/>
         <description value="Retrieve period PulseRate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8893-0&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-06-X-bloodpressure.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-06-X-bloodpressure.xml
@@ -13,7 +13,7 @@
     <test id="scenario6-1-retrieve-all-bloodpressure">
         <name value="Scenario 6.1"/>
         <description value="Retrieve all bloodpressure Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario6-2-retrieve-all-bloodpressure">
         <name value="Scenario 6.2"/>
         <description value="Retrieve latest bloodpressure Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|85354-9"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -48,7 +48,7 @@
     <test id="scenario6-3-retrieve-all-bloodpressures">
         <name value="Scenario 6.3"/>
         <description value="Retrieve period bloodpressure Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9&amp;date=ge${DATE, T, D,-14}&amp;date=le${DATE, T, D,-1}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -73,7 +73,7 @@
     <test id="scenario6-4-retrieve-all-bloodpressures">
         <name value="Scenario 6.4"/>
         <description value="Retrieve period bloodpressure Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-53}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-07-X-bodyweight.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-07-X-bodyweight.xml
@@ -13,7 +13,7 @@
     <test id="scenario7-1-retrieve-all-bodyweight">
         <name value="Scenario 7.1"/>
         <description value="Retrieve all bodyweight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|29463-7"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario7-2-retrieve-all-bodyweight">
         <name value="Scenario 7.2"/>
         <description value="Retrieve latest bodyweight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario7-3-retrieve-all-bodyweights">
         <name value="Scenario 7.3"/>
         <description value="Retrieve period bodyweight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|29463-7&amp;date=ge${DATE, T, D,-28}&amp;date=le${DATE, T, D,-1}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -59,7 +59,7 @@
     <test id="scenario7-4-retrieve-all-bodyweights">
         <name value="Scenario 7.4"/>
         <description value="Retrieve period bodyweight Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|29463-7&amp;date=ge${DATE, T, D,-200}&amp;date=le${DATE, T, D,-100}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-08-X-bloodglucose.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-08-X-bloodglucose.xml
@@ -13,7 +13,7 @@
     <test id="scenario8-1-retrieve-all-bloodglucose">
         <name value="Scenario 8.1"/>
         <description value="Retrieve all bloodglucose Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario8-2-retrieve-all-bloodglucose">
         <name value="Scenario 8.2"/>
         <description value="Retrieve latest bloodglucose Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|14760-3,http://loinc.org|14770-2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario8-3-retrieve-all-bloodglucoses">
         <name value="Scenario 8.3"/>
         <description value="Retrieve period bloodglucose Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2&amp;date=ge${DATE, T, D,-12}&amp;date=le${DATE, T, D,-1}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -73,7 +73,7 @@
     <test id="scenario8-4-retrieve-all-bloodglucoses">
         <name value="Scenario 8.4"/>
         <description value="Retrieve period bloodglucose Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-09-X-heartrate.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-09-X-heartrate.xml
@@ -13,7 +13,7 @@
     <test id="scenario9-1-retrieve-all-heartrate">
         <name value="Scenario 9.1"/>
         <description value="Retrieve all heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8867-4"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario9-2-retrieve-all-heartrate">
         <name value="Scenario 9.2"/>
         <description value="Retrieve latest heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8867-4"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -41,7 +41,7 @@
     <test id="scenario9-3-retrieve-all-heartrates">
         <name value="Scenario 9.3"/>
         <description value="Retrieve period heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8867-4&amp;date=ge${DATE, T, D,-15}&amp;date=le${DATE, T, D,-1}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -66,7 +66,7 @@
     <test id="scenario9-4-retrieve-all-heartrates">
         <name value="Scenario 9.4"/>
         <description value="Retrieve period heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8867-4&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-10-X-multiple.xml
+++ b/src/SelfMeasurements-2-0/Test/Retrieving-PHR/selfmeasurements-phr-retrieve-10-X-multiple.xml
@@ -13,7 +13,7 @@
     <test id="scenario10-1-retrieve-all-heartrate">
         <name value="Scenario 10.1"/>
         <description value="Retrieve all heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8310-5,http://loinc.org|8302-2,http://loinc.org|59408-5,http://loinc.org|8893-0,http://snomed.info/sct|422834003&amp;date=ge${DATE, T, D,-365}&amp;date=le${DATE, T, D, -14}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -23,7 +23,7 @@
     <test id="scenario10-2-retrieve-all-heartrate">
         <name value="Scenario 10.2"/>
         <description value="Retrieve all heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2,http://loinc.org|8867-4,http://loinc.org|29463-7,http://loinc.org|85354-9&amp;date=ge${DATE, T, D,-365}&amp;date=le${DATE, T, D,-14}"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -33,7 +33,7 @@
     <test id="scenario10-3-retrieve-all-heartrate">
         <name value="Scenario 10.3"/>
         <description value="Retrieve all heartrate Observation resources"/>
-        <nts:include value="medmij/test.phr.read" scope="common"
+        <nts:include value="medmij/test.phr.search" scope="common"
             resource="Observation"
             params="?category=http://hl7.org/fhir/observation-category|vital-signs"/>
         <nts:include value="assert.response.numResources" scope="common"


### PR DESCRIPTION
MM-5669 Operation read vervangen door search
read operation hoort bij operations waarvan een specifieke resource wordt opgevraagd. Search als er dmv parameters naar de juiste resource gezocht moeten worden. 