### PR TITLE
CL-62/MM-5611 Assert binary uit test 1.3 gehaald

### DIFF
--- a/output/STU3/PDFA-3-0/MedMij/Cert/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
+++ b/output/STU3/PDFA-3-0/MedMij/Cert/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
@@ -123,15 +123,6 @@
             <warningOnly value="false"/>
          </assert>
       </action>
-      <action>
-         <assert>
-            <description value="Make sure that the server of the test simulator returns the requested Binary resource."/>
-            <direction value="response"/>
-            <resource value="Binary"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
    </test>
    <test id="scenario1-3-retrieve-binary-2">
       <name value="Scenario 1.3 - Binary 2"/>
@@ -194,15 +185,6 @@
             <operator value="in"/>
             <responseCode value="200,201"/>
             <stopTestOnFail value="true"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <description value="Make sure that the server of the test simulator returns the requested Binary resource."/>
-            <direction value="response"/>
-            <resource value="Binary"/>
-            <stopTestOnFail value="false"/>
             <warningOnly value="false"/>
          </assert>
       </action>

--- a/output/STU3/PDFA-3-0/MedMij/Test/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
+++ b/output/STU3/PDFA-3-0/MedMij/Test/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
@@ -123,15 +123,6 @@
             <warningOnly value="false"/>
          </assert>
       </action>
-      <action>
-         <assert>
-            <description value="Make sure that the server of the test simulator returns the requested Binary resource."/>
-            <direction value="response"/>
-            <resource value="Binary"/>
-            <stopTestOnFail value="false"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
    </test>
    <test id="scenario1-3-retrieve-binary-2">
       <name value="Scenario 1.3 - Binary 2"/>
@@ -194,15 +185,6 @@
             <operator value="in"/>
             <responseCode value="200,201"/>
             <stopTestOnFail value="true"/>
-            <warningOnly value="false"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <description value="Make sure that the server of the test simulator returns the requested Binary resource."/>
-            <direction value="response"/>
-            <resource value="Binary"/>
-            <stopTestOnFail value="false"/>
             <warningOnly value="false"/>
          </assert>
       </action>

--- a/src/PDFA-3-0/Cert/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
+++ b/src/PDFA-3-0/Cert/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
@@ -25,13 +25,17 @@
     <test id="scenario1-3-retrieve-binary-1">
         <name value="Scenario 1.3 - Binary 1"/>
         <description value="Read Binary resource."/>
-        <nts:include value="medmij/test.phr.successfulRead" scope="common"
+        <nts:include value="medmij/test.phr.read" scope="common"
             resource="Binary" params="/${binary1-id}"/>
+        <nts:include value="assert.response.success" scope="common"/>
+
     </test>
     <test id="scenario1-3-retrieve-binary-2">
         <name value="Scenario 1.3 - Binary 2"/>
         <description value="Read Binary resource"/>
-        <nts:include value="medmij/test.phr.successfulRead" scope="common"
+        <nts:include value="medmij/test.phr.read" scope="common"
             resource="Binary" params="/${binary2-id}"/>
+        <nts:include value="assert.response.success" scope="common"/>
+            
     </test>
 </TestScript>


### PR DESCRIPTION
Assert op binary weggehaald bij PHR test 1.3 omdat deze niet relevant is voor dit scenario. 
testrun: https://my.interoplab.eu/uc-nictiz/tests/instance/68d2acc1c8471e967ead09c8